### PR TITLE
Add fromcapacity implementation based on OL3

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Représente les fonds de plan.
 * **layers**: Nom de la ressource ogc
 * **format**: Format image du fond de plan 
 * **visible**: Visibilité du fond de plan
-* **fromcapacity**: Attribut spécifique pour les fonds de plan WMTS. Permet la construction de layers à partir des capactiy. (**A IMPLEMENTER **)
+* **fromcapacity**: Attribut spécifique pour les fonds de plan WMTS. Permet la construction de layers à partir des capactiy.
 * **attribution**: Imagette de copyright.
 * **style** : Style de la couche
 * **matrixset** : option spécifique au flux WMTS

--- a/lib/mviewer.js
+++ b/lib/mviewer.js
@@ -1585,12 +1585,31 @@ mviewer = (function () {
                             style: params.attr("style")
                         });
                         WMTSOptions.attributions = [new ol.Attribution({html:params.attr("attribution")})];
-                        l = new ol.layer.Tile({ source: new ol.source.WMTS(WMTSOptions) })
-                        l.setVisible(false);
+                        l = new ol.layer.Tile({ source: new ol.source.WMTS(WMTSOptions) });
                         l.set('name', params.attr("label"));
                         l.set('blid', params.attr("id"));
-                        _map.addLayer(l);
+                        _map.getLayers().insertAt(0,l);
                         _backgroundLayers.push(l);
+                        if( params.attr("visible") == 'true' ) {
+                            l.setVisible(true);
+                            if (_legendRenderer === "canvas") {
+                               _mapLayersChange();
+                            }
+                            $.each(_backgroundLayers, function (id, layer) {
+                                var opt = $(_options).find("baselayers").attr("style");
+                                var elem = (opt === "gallery") ? $('#' + layer.get('blid') + '_btn').closest('li') : $('#' + layer.get('blid') + '_btn');
+                                if (layer.getVisible()) {
+                                    $(elem).find("a").attr("data-theme", "a").removeClass("ui-btn-b ui-btn-up-b").addClass("ui-btn-a ui-btn-up-a").enhanceWithin();
+                                } else {
+                                    $(elem).find("a").attr("data-theme", "b").removeClass("ui-btn-a ui-btn-up-a").addClass("ui-btn-b ui-btn-up-b").enhanceWithin();
+                                }
+                                if (opt === "gallery") {
+                                    $('#backgroundlayerstoolbar').collapsible( "collapse" );
+                                }
+                            });
+                        } else {
+                            l.setVisible(false);
+                        }
                     }
                 });
             }
@@ -2546,7 +2565,6 @@ mviewer = (function () {
                 })[0]) {
 
                     this.setBaseLayer(config.lb);
-                    //todo asynchronous layers WMTS
                 } else {
                     this.setBaseLayer($(xml).find('baselayers').find('[visible="true"]').attr("id"));
                 }

--- a/lib/mviewer.js
+++ b/lib/mviewer.js
@@ -1577,7 +1577,20 @@ mviewer = (function () {
                         REQUEST: "GetCapabilities"
                     },
                     success: function (xml) {
-                        // TODO  WMTS Capabilities in beta2                        
+                        var getCapabilitiesResult = (new ol.format.WMTSCapabilities()).read(xml);
+                        var WMTSOptions = ol.source.WMTS.optionsFromCapabilities( getCapabilitiesResult, { 
+                            layer: params.attr("layers"), 
+                            matrixSet: params.attr("matrixset"), 
+                            format: params.attr('format'), 
+                            style: params.attr("style")
+                        });
+                        WMTSOptions.attributions = [new ol.Attribution({html:params.attr("attribution")})];
+                        l = new ol.layer.Tile({ source: new ol.source.WMTS(WMTSOptions) })
+                        l.setVisible(false);
+                        l.set('name', params.attr("label"));
+                        l.set('blid', params.attr("id"));
+                        _map.addLayer(l);
+                        _backgroundLayers.push(l);
                     }
                 });
             }


### PR DESCRIPTION
This allow to auto-configure WMTS layer from getCapabilities if "fromcapacity" is set to true.

It use the OpenLayers 3 classes : 

- ol.format.WMTSCapabilities : to parse getCapabilities XML to an object
- ol.source.WMTS.optionsFromCapabilities() : to generate WMTS config from the getCapabilities object and config.xml parameters