### PR TITLE
Load layer indexed with Fuse only once (fix #59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,15 +204,15 @@ recherche suivantes active : "features" et "static".
 
 ### fuse
 
-Fuse est une bibliothèque javascript utilisée par mviewer pour indexer le contenu de couches stockées sous forme de 
-fichiers GeoJSON (cf. http://fusejs.io/). Elle donne une alternative plus légère à l'utilisation d'index Elasticsearch. 
-Contrairement à Elasticsearch, le paramétrage de Fuse ne fait l'objet d'un nœud spécifique. Son paramétrage est réalisé 
-directement au niveau des nœuds des couches concernées à l'aide des attributs "searchable", "searchengine", 
-"fusesearchkeys" et "fusesearchresult".
+Fuse est une bibliothèque javascript utilisée par mviewer pour indexer le contenu de couches de données vecteur légères 
+(cf. http://fusejs.io/). Elle donne une alternative plus simple et économique que la mise en œuvre d'index 
+Elasticsearch. Contrairement à ce dernier, le paramétrage de Fuse ne fait pas l'objet d'un nœud spécifique. Son 
+paramétrage est réalisé directement au niveau des nœuds des couches concernées à l'aide des attributs "searchable", 
+"searchengine", "fusesearchkeys" et "fusesearchresult".
 
 La recherche basée sur Fuse n'est active que pour les couches dont les attributs "searchable" et "searchengine" 
-valent respectivement "true" et "fuse". Cette recherche n'est active que lorsque l'option de recherche est active : 
-"features".
+valent respectivement "true" et "fuse". Cette recherche n'est active que lorsque l'option de recherche suivante est 
+active : "features".
 
 ### searchparameters
 
@@ -328,7 +328,7 @@ Exemple : insee=35000 ou INTERSECTS(the_geom, POINT (-74.817265 40.5296504))
 * **searchable**: Booléen précisant si la couche est interrogeable via la barre de recherche.
 * **searchengine**: elasticsearch|fuse. Défault=elasticsearch.
 * **searchid**: Nom du champ à utiliser côté WMS afin de faire le lien avec l'_id elasticsearch.
-* **fusesearchkeys**: Chaîne de caractères contenant le liste des champs du fichier GeoJSON à indexer pour la 
+* **fusesearchkeys**: Chaîne de caractères contenant le liste des champs de la couche à indexer pour la 
 recherche. Les noms des champs doivent être séparés par des virgules. A n'utiliser que si searchengine = fuse.
 * **fusesearchresult**: Chaîne de caractères décrivant l'information à afficher dans les résultats de recherche. 
 Cette chaîne contient soit le nom d'un champ de la couche soit un template Mustache combinant plusieurs noms de champs. 

--- a/lib/mviewer.js
+++ b/lib/mviewer.js
@@ -1646,38 +1646,6 @@ mviewer = (function () {
             _queryableLayers.push(l);
         }
 
-        if (oLayer.scale) {
-            _scaledDependantLayers.push(oLayer);
-        }
-        if (oLayer.dynamiclegend) {
-            _scaledDependantLayersLegend.push(oLayer);
-        }
-        _overLayers[oLayer.id] = oLayer;
-
-        if (oLayer.metadatacsw && oLayer.metadatacsw.search("http")>=0) {
-            $.ajax({
-                dataType: "xml",
-                layer: oLayer.id,
-                url:  _ajaxURL(oLayer.metadatacsw),
-                success: function (result) {
-                    var summary = "";
-                    if ($(result).find("dct\\:abstract, abstract").length > 0) {
-                        summary = '<p>'+ $(result).find("dct\\:abstract, abstract").text()+ '</p>';
-                    } else {
-                        summary = '<p>'+$(result).find("gmd\\:identificationInfo, identificationInfo").find("gmd\\:MD_DataIdentification,  MD_DataIdentification")
-                            .find("gmd\\:abstract, abstract").find("gco\\:CharacterString, CharacterString").text()+ '</p>';
-                    }
-                    if (_overLayers[this.layer].metadata) {
-                        summary += '<a href="'+_overLayers[this.layer].metadata+'" target="_blank">En savoir plus</a>';
-                    }
-                    _overLayers[this.layer].summary = summary;
-                    //update visible layers on the map
-                    $('#'+this.layer+'-layer-summary').attr("data-content", summary);
-                }
-            });
-        }
-        _map.addLayer(l);
-
         if (oLayer.searchable) {
             switch (oLayer.searchengine) {
                 case "fuse":
@@ -1726,6 +1694,38 @@ mviewer = (function () {
                     break;
             }
         }
+
+        if (oLayer.scale) {
+            _scaledDependantLayers.push(oLayer);
+        }
+        if (oLayer.dynamiclegend) {
+            _scaledDependantLayersLegend.push(oLayer);
+        }
+        _overLayers[oLayer.id] = oLayer;
+
+        if (oLayer.metadatacsw && oLayer.metadatacsw.search("http")>=0) {
+            $.ajax({
+                dataType: "xml",
+                layer: oLayer.id,
+                url:  _ajaxURL(oLayer.metadatacsw),
+                success: function (result) {
+                    var summary = "";
+                    if ($(result).find("dct\\:abstract, abstract").length > 0) {
+                        summary = '<p>'+ $(result).find("dct\\:abstract, abstract").text()+ '</p>';
+                    } else {
+                        summary = '<p>'+$(result).find("gmd\\:identificationInfo, identificationInfo").find("gmd\\:MD_DataIdentification,  MD_DataIdentification")
+                            .find("gmd\\:abstract, abstract").find("gco\\:CharacterString, CharacterString").text()+ '</p>';
+                    }
+                    if (_overLayers[this.layer].metadata) {
+                        summary += '<a href="'+_overLayers[this.layer].metadata+'" target="_blank">En savoir plus</a>';
+                    }
+                    _overLayers[this.layer].summary = summary;
+                    //update visible layers on the map
+                    $('#'+this.layer+'-layer-summary').attr("data-content", summary);
+                }
+            });
+        }
+        _map.addLayer(l);
     };
 
 

--- a/lib/mviewer.js
+++ b/lib/mviewer.js
@@ -1385,9 +1385,10 @@ mviewer = (function () {
                         // a Mustache template
                         result_label = Mustache.render(_fuseSearchResult, element);
                     }
+                    var coordinates = element.geometry.coordinates;
                     str += '<li class="fuse list-group-item" data-icon="false" title="' + result_label + '">' +
                         '<a href="#" onclick="mviewer.zoomToLocation('
-                        + element.geometry.coordinates[0] + ',' + element.geometry.coordinates[1] + ','
+                        + coordinates[0] + ',' + coordinates[1] + ','
                         + zoom + ',\'' + result_label.replace("'", "*") + '\');">'
                         + result_label + '</a></li>';
                 });
@@ -1644,44 +1645,7 @@ mviewer = (function () {
         if (oLayer.queryable) {
             _queryableLayers.push(l);
         }
-        if (oLayer.searchable) {
-            switch (oLayer.searchengine) {
-                case "fuse":
-                    _searchableFuseLayers.push(l);
-                    var options = {
-                        shouldSort: true,
-                        threshold: 0.3,
-                        location: 0,
-                        distance: 100,
-                        maxPatternLength: 32,
-                        minMatchCharLength: 2,
-                        keys: oLayer.fusesearchkeys.split(',')
-                    };
-                    var layerSourceUrl = l.getSource().getUrl();
-                    $.getJSON( layerSourceUrl, function( data ) {
-                        j = [];
-                        var crs =  (data.crs && data.crs.properties && data.crs.properties.names) ? data.crs.properties.name : undefined;
-                        data.features.forEach(function(element){
-                            prop = element.properties;
-                            var geom =  new ol.format.GeoJSON().readGeometry(element.geometry);
-                            if (crs) {
-                                prop.geometry =  new ol.format.GeoJSON().writeGeometryObject(geom.transform(crs,'EPSG:4326'));
-                            } else {
-                                prop.geometry =  new ol.format.GeoJSON().writeGeometryObject(geom);
-                            }
-                            j.push(prop);
-                            prop.fusesearchresult = oLayer.fusesearchresult;
-                        });
 
-                        var list = $.map(j, function(el) { return el });
-                        _fuseSearchData[oLayer.id] = new Fuse(list, options);
-                    });
-                    break;
-                case "elasticsearch":
-                    _searchableElasticsearchLayers.push(l);
-                    break;
-            }
-        }
         if (oLayer.scale) {
             _scaledDependantLayers.push(oLayer);
         }
@@ -1713,6 +1677,55 @@ mviewer = (function () {
             });
         }
         _map.addLayer(l);
+
+        if (oLayer.searchable) {
+            switch (oLayer.searchengine) {
+                case "fuse":
+                    _searchableFuseLayers.push(l);
+                    var options = {
+                        shouldSort: true,
+                        threshold: 0.3,
+                        location: 0,
+                        distance: 100,
+                        maxPatternLength: 32,
+                        minMatchCharLength: 2,
+                        keys: oLayer.fusesearchkeys.split(',')
+                    };
+
+                    var layerSource = l.getSource();
+                    layerSource.on('change', function(event) {
+                        var source = event.target;
+
+                        if (source.getState() === "ready" && !_fuseSearchData[oLayer.id] ) {
+                            var features = source.getFeatures();
+                            var geojsonFormat = new ol.format.GeoJSON();
+                            var mapProj = _map.getView().getProjection();
+
+                            var j = [];
+
+                            features.forEach(function(feature) {
+
+                                var geojsonFeature = geojsonFormat.writeFeatureObject(feature);
+                                var wgs84Geom = feature.getGeometry().clone().transform(mapProj, "EPSG:4326");
+
+                                var prop = geojsonFeature.properties;
+                                prop.geometry = geojsonFormat.writeGeometryObject(wgs84Geom);
+                                prop.fusesearchresult = oLayer.fusesearchresult;
+
+                                j.push(prop);
+                            });
+
+                            var list = $.map(j, function(el) { return el });
+                            _fuseSearchData[oLayer.id] = new Fuse(list, options);
+                        }
+                    });
+                    break;
+
+                case "elasticsearch":
+                    _searchableElasticsearchLayers.push(l);
+                    break;
+            }
+        }
     };
 
 


### PR DESCRIPTION
This fix has only been tested on a geojson layer and a custom layer loading a geojson file.
The process of the searchable property of the layer has moved just after _map.addLayer allowing access to the features of layer. I hope this don't break the process of layers indexed with Elasticsearch.