### PR TITLE
Add support for GetFeatureInfo from ArcGIS Server WMS services

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,9 @@ Exemple : "{{name}} ({{city}})". A n'utiliser que si les infobulles sont activé
 * **secure**: Précise si la couche est protégée ( méchanisme geoserver ) auquel cas un test est affectué pour savoir 
 si la couche est accessible. SI ce n'est pas le cas, la couche est retirée du panneau et de la carte.
 * **toplayer**: Précise si la couche demeure figée". Booléen. Défaut = true.
-* **infoformat**: Format du GetFeatureInfo. 2 formats sont supportés : text/html et application/vnd.ogc.gml.
+* **infoformat**: Format du GetFeatureInfo. 2 formats sont supportés : text/html, application/vnd.ogc.gml (pour 
+GeoServer et MapServer), application/vnd.esri.wms_raw_xml ou application/vnd.esri.wms_featureinfo_xml (pour ArcGIS 
+Server).
 * **featurecount**: Nombre d'éléments retournés lors de l'interrogation.
 * **style**: Style(s) de la couche. Si plusieurs styles , utiliser la virgule comme séparateur.
 Si la couche est de type wms, il faut faire référence à un style sld.
@@ -390,9 +392,11 @@ actualisée à chaque changement d'échelle de la carte.
 
 ####### Nœuds
 
-* **<template>**: contient le template type Mustache (https://github.com/janl/mustache.js) à appliquer à la fiche d'information.
-Pour fonctionner, il faut que le paramètre **infoformat** ait la valeur "application/vnd.ogc.gml".
-Le template peut être un fichier statique ex templates/template1.mst ou directement saisi dans le nœud <template> avec les balises <![CDATA[ ]]>.
+* **<template>**: contient le template type Mustache (https://github.com/janl/mustache.js) à appliquer à la fiche 
+d'information. Pour fonctionner, il faut que le paramètre **infoformat** ait la valeur "application/vnd.ogc.gml" (pour 
+GeoServer et MapServer), voire "application/vnd.esri.wms_raw_xml" ou "application/vnd.esri.wms_featureinfo_xml" (pour 
+ArcGIS Server). Le template peut être un fichier statique ex templates/template1.mst ou directement saisi dans le nœud 
+<template> avec les balises <![CDATA[ ]]>.
 
 
 Utilisation		
@@ -403,6 +407,9 @@ Utilisation
 Il est possible d'instancier un mviewer avec des paramètres transmis par URL
 
 * **config**: Fichier de configuration à charger ex: mviewer/?config=demo/l93.xml
-* **theme**: Theme css à utiliser ex: ?theme=geobretagne pour charger le theme doit être dans css/themes/geobretagne.css.
-* **wmc**: liste des contextes OGC WMC (séparés par des virgules) à charger afin d'alimenter le panel de gauche ex: mviewer/?wmc=demo/hydro.wmc
-* **popup**: true ou false. Si true, Une popup s'affiche sur la carte afin d'afficher le résultat de l'interrogation de couches.
+* **theme**: Theme css à utiliser ex: ?theme=geobretagne pour charger le theme doit être dans 
+css/themes/geobretagne.css.
+* **wmc**: liste des contextes OGC WMC (séparés par des virgules) à charger afin d'alimenter le panel de gauche ex : 
+mviewer/?wmc=demo/hydro.wmc
+* **popup**: true ou false. Si true, Une popup s'affiche sur la carte afin d'afficher le résultat de l'interrogation de 
+couches.

--- a/lib/mviewer.js
+++ b/lib/mviewer.js
@@ -2182,15 +2182,12 @@ mviewer = (function () {
      * Private Method:  parseXML
      *
      */
-//TODO parseXML, add ArcGIS XML
     var _parseXML = function (xml) {
         var results = $.xml2json(xml);
 		var list = [];
-        var geoserver = false;
         var o = {features: []};
 		// GEOSERVER
         if (results.featureMember) {
-            geoserver = true;
             if ($.isArray(results.featureMember) === false) {
                 list.push(results.featureMember);
             } else {
@@ -2198,7 +2195,6 @@ mviewer = (function () {
             }
             for (var j=0; j<list.length; j++) {
                 var obj=list[j];
-                //GEOSERVER
                 for(var prop in obj) {
                     if(obj.hasOwnProperty(prop))
                         o.features.push({layername:prop, properties:obj[prop]});

--- a/lib/mviewer.js
+++ b/lib/mviewer.js
@@ -719,7 +719,11 @@ mviewer = (function () {
 
                     switch (contentType.split(";")[0]) {
                         case "text/html":
-                            html = layerResponse;
+                            if ((typeof layerResponse === 'string')
+                                && (layerResponse.search('<!--nodatadetect--><!--nodatadetect-->')<0)
+                                && (layerResponse.search('<!--nodatadetect-->\n<!--nodatadetect-->')<0)) {
+                                html = layerResponse;
+                            }
                             break;
                         case "application/vnd.ogc.gml":
                             if ($.isXMLDoc(layerResponse)) {

--- a/lib/mviewer.js
+++ b/lib/mviewer.js
@@ -696,7 +696,7 @@ mviewer = (function () {
                     urls.push({url:url, layerinfos: _overLayers[visibleLayers[i].get('mviewerid')]});
                 }
             }
-           
+
             var requests = [];
             var carrousel=false;
             var callback = function (result) {
@@ -706,94 +706,99 @@ mviewer = (function () {
                     var contentType = response.contenttype;
 					var layerResponse = response.response;
                     var slide = null;
-                    if ((typeof layerResponse === 'string')
-                        && (layerResponse.search('<!--nodatadetect--><!--nodatadetect-->')<0)
-                        && (layerResponse.search('<!--nodatadetect-->\n<!--nodatadetect-->')<0)) {
-                        id_tab[panel]+=1;
-                        var name = layerinfos.name;
-                        var theme = layerinfos.theme;
-                        var layerid = layerinfos.layerid;
-                        var theme_icon = "fa-lg fa-chevron-circle-right";
-                        if ($(_options).find('theme[id="'+theme+'"]').attr("icon")) {
-                            theme_icon = "fa-lg fa-" + $(_options).find('theme[id="'+theme+'"]').attr("icon");
+                    id_tab[panel]+=1;
+                    var name = layerinfos.name;
+                    var theme = layerinfos.theme;
+                    var layerid = layerinfos.layerid;
+                    var theme_icon = "fa-lg fa-chevron-circle-right";
+                    if ($(_options).find('theme[id="'+theme+'"]').attr("icon")) {
+                        theme_icon = "fa-lg fa-" + $(_options).find('theme[id="'+theme+'"]').attr("icon");
+                    }
+                    var xml = null;
+                    var html = null;
+
+                    switch (contentType.split(";")[0]) {
+                        case "text/html":
+                            html = layerResponse;
+                            break;
+                        case "application/vnd.ogc.gml":
+                            if ($.isXMLDoc(layerResponse)) {
+                                xml = layerResponse;
+                            } else {
+                                xml = $.parseXML(layerResponse);
+                            }
+                            break;
+                        case "application/vnd.esri.wms_raw_xml":
+                        case "application/vnd.esri.wms_featureinfo_xml":
+                            if ($.isXMLDoc(layerResponse)) {
+                                xml = layerResponse;
+                            } else {
+                                xml = $.parseXML(layerResponse);
+                            }
+                            break;
+                        default :
+                            _message("Ce format de réponse : " + contentType +" n'est pas pris en charge");
+                    }
+                    if (html) {
+                        tabs[panel].splice(response.layerinfos.rank,1,
+                            ['<li title="'+name+'" data-layerid="'+layerid+'">',
+                                '<a onclick="mviewer.setInfoPanelTitle(this,\''+panel+'\');" title="'+name+'" href="#slide-'+panel+'-'+id_tab[panel]+'" data-toggle="tab">',
+                                    '<span class="fa '+theme_icon+'"></span>',
+                                '</a></li>'].join(" "));
+                        slide =$(new TPLInfopanel( panel, id_tab).html());
+
+                        //test si présence d'une classe .carrousel eg template geoserver.
+                        //Les éléments trouvés servent à la création d'un carrousel dédié
+                        var carrousel_data=$(layerResponse).find(".carrousel li").addClass("item");
+                        carrousel_data.first().addClass("active");
+                        if(carrousel_data.length == 0){
+                            $(slide).find("ul").append('<li class="item active">'+layerResponse+'</li>');
+                            $(slide).find(".carousel-control").remove();
                         }
-                        
-                        var gml = null;
-                        var html = null;
-                       
-                        switch (contentType.split(";")[0]) {
-                            case "text/html":
-                                html = layerResponse;
-                                break;							
-                            case "application/vnd.ogc.gml" :
-                                gml = $.parseXML(layerResponse);
-                                break;							
-                            default :                                
-                                _message("Ce format de réponse : " + contentType +" n'est pas pris en charge");												
-                        }					
-                        if (html) {
-                            tabs[panel].splice(response.layerinfos.rank,1,                                
-                                ['<li title="'+name+'" data-layerid="'+layerid+'">',
-                                    '<a onclick="mviewer.setInfoPanelTitle(this,\''+panel+'\');" title="'+name+'" href="#slide-'+panel+'-'+id_tab[panel]+'" data-toggle="tab">',
-                                        '<span class="fa '+theme_icon+'"></span>',
-                                    '</a></li>'].join(" "));
-                            slide =$(new TPLInfopanel( panel, id_tab).html());
-                                                       
-                            //test si présence d'une classe .carrousel eg template geoserver.
-                            //Les éléments trouvés servent à la création d'un carrousel dédié
-                            var carrousel_data=$(layerResponse).find(".carrousel li").addClass("item");
-                            carrousel_data.first().addClass("active");
-                            if(carrousel_data.length == 0){
-                                $(slide).find("ul").append('<li class="item active">'+layerResponse+'</li>');
-                                $(slide).find(".carousel-control").remove();
-                            }
-                            else {							
-                                for( var i=0; i<carrousel_data.length; i++){						
-                                    var page = $(slide).find("ul").append(carrousel_data[i]);
-                                    if (carrousel_data.length > 1) {
-                                        var li = $(page).find("li")[i];
-                                        $(li).append('<span class="badge counter-slide">'+(i+1)+'/'+carrousel_data.length+'</span>');
-                                    } else {
-                                        $(slide).find(".carousel-control").remove();
-                                    }
-                                   
-                                }
-                                // ajout des ctrls du carrousel
-                            }
-                        } else {
-                            if (gml) {
-                                var obj = _parseGML(gml);
-                                if (obj.features.length > 0) {
-                                    tabs[panel].splice(response.layerinfos.rank,1,                                       
-                                        ['<li title="'+name+'" data-layerid="'+layerid+'">',
-                                            '<a onclick="mviewer.setInfoPanelTitle(this,\''+panel+'\');" title="'+name+'" href="#slide-'+panel+'-'+id_tab[panel]+'" data-toggle="tab">',
-                                                '<span class="fa '+theme_icon+'"></span>',
-                                             '</a></li>'].join(" "));
-                                    slide = $(new TPLInfopanel( panel, id_tab).html());
-                                    if (layerinfos.template) {
-                                        $(slide).find("ul").append(applyTemplate(obj.features.reverse(), layerinfos));
-                                    } else {
-                                        $(slide).find("ul").append(createContentHtml(obj.features.reverse(), layerinfos));
-                                    }
-                                    $(slide).find("li.item").first().addClass("active");
-                                }
-                                if (obj.features.length === 1) {
-                                    $(slide).find(".carousel-control").remove();
-                                    $(slide).find(".counter-slide").remove();
+                        else {
+                            for( var i=0; i<carrousel_data.length; i++){
+                                var page = $(slide).find("ul").append(carrousel_data[i]);
+                                if (carrousel_data.length > 1) {
+                                    var li = $(page).find("li")[i];
+                                    $(li).append('<span class="badge counter-slide">'+(i+1)+'/'+carrousel_data.length+'</span>');
                                 } else {
-                                     var totalItems = $(slide).find("li.item").length;
-                                     $(slide).find("li.item").each(function (i, item) {
-                                        $(item).attr("data-counter",(i+1)+'/'+totalItems);
-                                     });
-                                     $(slide).find(".counter-slide").text("1/"+ totalItems);
+                                    $(slide).find(".carousel-control").remove();
                                 }
+
                             }
-                        }
-                        if (slide) {
-                            featureInfosHtml[panel].push(slide);
+                            // ajout des ctrls du carrousel
                         }
                     } else {
-                        console.log(layerResponse, contentType);
+                        if (xml) {
+                            var obj = _parseXML(xml);
+                            if (obj.features.length > 0) {
+                                tabs[panel].splice(response.layerinfos.rank,1,
+                                    ['<li title="'+name+'" data-layerid="'+layerid+'">',
+                                        '<a onclick="mviewer.setInfoPanelTitle(this,\''+panel+'\');" title="'+name+'" href="#slide-'+panel+'-'+id_tab[panel]+'" data-toggle="tab">',
+                                            '<span class="fa '+theme_icon+'"></span>',
+                                         '</a></li>'].join(" "));
+                                slide = $(new TPLInfopanel( panel, id_tab).html());
+                                if (layerinfos.template) {
+                                    $(slide).find("ul").append(applyTemplate(obj.features.reverse(), layerinfos));
+                                } else {
+                                    $(slide).find("ul").append(createContentHtml(obj.features.reverse(), layerinfos));
+                                }
+                                $(slide).find("li.item").first().addClass("active");
+                            }
+                            if (obj.features.length === 1) {
+                                $(slide).find(".carousel-control").remove();
+                                $(slide).find(".counter-slide").remove();
+                            } else {
+                                 var totalItems = $(slide).find("li.item").length;
+                                 $(slide).find("li.item").each(function (i, item) {
+                                    $(item).attr("data-counter",(i+1)+'/'+totalItems);
+                                 });
+                                 $(slide).find(".counter-slide").text("1/"+ totalItems);
+                            }
+                        }
+                    }
+                    if (slide) {
+                        featureInfosHtml[panel].push(slide);
                     }
                 });
                 $.each(featureInfosHtml, function (panel, value) {
@@ -2170,25 +2175,25 @@ mviewer = (function () {
     };
 
      /**
-     * Private Method:  parseGML
+     * Private Method:  parseXML
      *
      */
-
-    var _parseGML = function (gml) {
-        var results = $.xml2json(gml);
-		var liste = [];
+//TODO parseXML, add ArcGIS XML
+    var _parseXML = function (xml) {
+        var results = $.xml2json(xml);
+		var list = [];
         var geoserver = false;
         var o = {features: []};
-		//GEOSERVER
+		// GEOSERVER
         if (results.featureMember) {
             geoserver = true;
             if ($.isArray(results.featureMember) === false) {
-                liste.push(results.featureMember);
+                list.push(results.featureMember);
             } else {
-                liste = results.featureMember;
+                list = results.featureMember;
             }
-            for (var j=0; j<liste.length ;j++) {
-                var obj=liste[j];
+            for (var j=0; j<list.length; j++) {
+                var obj=list[j];
                 //GEOSERVER
                 for(var prop in obj) {
                     if(obj.hasOwnProperty(prop))
@@ -2196,7 +2201,7 @@ mviewer = (function () {
                 }
             }
         }
-        //MAPSERVER Huge hack
+        // MAPSERVER Huge hack
         for (var p in results) {
             if (typeof(results[p]) === 'object') {
                 //Search for response type : layername_layer & layername_feature
@@ -2209,6 +2214,42 @@ mviewer = (function () {
                             o.features.push({layername:mslayer, properties:results[mslayer + '_layer'][mslayer + '_feature'][k]});
                         }
                     }
+                }
+            }
+        }
+
+        // ArcGIS Server
+        if (results.FeatureInfoCollection) {
+            arcgis = true;
+
+            var feat_info_col_list = [];
+
+            if ($.isArray(results.FeatureInfoCollection) === false) {
+                feat_info_col_list.push(results.FeatureInfoCollection);
+            } else {
+                feat_info_col_list = results.FeatureInfoCollection;
+            }
+
+            for (var i=0; i<feat_info_col_list.length; i++) {
+                feat_info_col = feat_info_col_list[i];
+                var feat_info_list = [];
+                var layer_name = feat_info_col.layername;
+
+                if ($.isArray(feat_info_col.FeatureInfo) === false) {
+                    feat_info_list.push(feat_info_col.FeatureInfo);
+                } else {
+                    for (var j=0; j<feat_info_col.FeatureInfo.length ;j++) {
+                        feat_info_list.push(feat_info_col.FeatureInfo[j]);
+                    }
+                }
+
+                for (var k=0; k<feat_info_list.length; k++) {
+                    var field_obj=feat_info_list[k];
+                    var feat_obj = {};
+                    for (var field in field_obj.Field) {
+                        feat_obj[field_obj.Field[field].FieldName] = field_obj.Field[field].FieldValue;
+                    }
+                    o.features.push({layername:layer_name, properties:feat_obj});
                 }
             }
         }

--- a/lib/mviewer.js
+++ b/lib/mviewer.js
@@ -2204,28 +2204,8 @@ mviewer = (function () {
                         o.features.push({layername:prop, properties:obj[prop]});
                 }
             }
-        }
-        // MAPSERVER Huge hack
-        for (var p in results) {
-            if (typeof(results[p]) === 'object') {
-                //Search for response type : layername_layer & layername_feature
-                var mslayer = p.substring(0,p.search('_layer')); //eg. STQ_layer
-                if (results[mslayer + '_layer'] && results[mslayer + '_layer'][mslayer + '_feature']) {
-                    if ($.isArray(results[mslayer + '_layer'][mslayer + '_feature']) === false) {
-                        o.features.push({layername:mslayer, properties:results[mslayer + '_layer'][mslayer + '_feature']});
-                    } else {
-                        for (var k=0; k<results[mslayer + '_layer'][mslayer + '_feature'].length ;k++) {
-                            o.features.push({layername:mslayer, properties:results[mslayer + '_layer'][mslayer + '_feature'][k]});
-                        }
-                    }
-                }
-            }
-        }
-
-        // ArcGIS Server
-        if (results.FeatureInfoCollection) {
-            arcgis = true;
-
+        } else if (results.FeatureInfoCollection) {
+            // ArcGIS Server
             var feat_info_col_list = [];
 
             if ($.isArray(results.FeatureInfoCollection) === false) {
@@ -2254,6 +2234,23 @@ mviewer = (function () {
                         feat_obj[field_obj.Field[field].FieldName] = field_obj.Field[field].FieldValue;
                     }
                     o.features.push({layername:layer_name, properties:feat_obj});
+                }
+            }
+        } else {
+            // MAPSERVER Huge hack
+            for (var p in results) {
+                if (typeof(results[p]) === 'object') {
+                    //Search for response type : layername_layer & layername_feature
+                    var mslayer = p.substring(0,p.search('_layer')); //eg. STQ_layer
+                    if (results[mslayer + '_layer'] && results[mslayer + '_layer'][mslayer + '_feature']) {
+                        if ($.isArray(results[mslayer + '_layer'][mslayer + '_feature']) === false) {
+                            o.features.push({layername:mslayer, properties:results[mslayer + '_layer'][mslayer + '_feature']});
+                        } else {
+                            for (var k=0; k<results[mslayer + '_layer'][mslayer + '_feature'].length ;k++) {
+                                o.features.push({layername:mslayer, properties:results[mslayer + '_layer'][mslayer + '_feature'][k]});
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
This pull request adds support for GetFeatureInfo from ArcGIS Server WMS services.
It adds two possible infoformats which are specific to ArcGIS Server: "application/vnd.esri.wms_raw_xml" and "application/vnd.esri.wms_featureinfo_xml".
These formats are XML not GML.
Therefore I replaced in the original source code "gml" by "xml" in order to be more generic.

Since I haven't found any ArcGIS server with CORS activated, I used a local proxy for retrieving the GetFeatureInfo responses.

I updated the readme file.