### PR TITLE
Issue 69

### DIFF
--- a/lib/mviewer.js
+++ b/lib/mviewer.js
@@ -1442,11 +1442,11 @@ mviewer = (function () {
                         // a Mustache template
                         result_label = Mustache.render(_fuseSearchResult, element);
                     }
-                    var coordinates = element.geometry.coordinates;
+                    var geom = new ol.format.GeoJSON().readGeometry(element.geometry);
+                    var xyz = _getLonLatZfromGeometry(geom, 'EPSG:4326', zoom);
                     str += '<li class="fuse list-group-item" data-icon="false" title="' + result_label + '">' +
                         '<a href="#" onclick="mviewer.zoomToLocation('
-                        + coordinates[0] + ',' + coordinates[1] + ','
-                        + zoom + ',\'' + result_label.replace("'", "*") + '\');">'
+                        + xyz + ');">'
                         + result_label + '</a></li>';
                 });
             }
@@ -2369,6 +2369,27 @@ mviewer = (function () {
             ticks.push(i);
         }
         return ticks;
+    };
+
+        /**
+         * Private Method: _getLonLatZfromGeometry
+         *
+         */
+
+    var _getLonLatZfromGeometry = function (geometry, proj, maxzoom) {
+        var xyz = "";
+        if (geometry.getType === "Point") {
+            xyz = geometry.getCoordinates().join(",") + "," + maxzoom || 15;
+        } else {
+            var extent = geometry.getExtent();
+            var projExtent = ol.proj.transformExtent(extent, 'EPSG:4326', _projection.getCode());
+            var resolution = _map.getView().getResolutionForExtent(projExtent, _map.getSize());
+            var zoom = parseInt(_map.getView().getZoomForResolution(resolution));
+            if (maxzoom && zoom > maxzoom) { zoom = maxzoom; }
+            var center = ol.proj.transform(ol.extent.getCenter(extent),proj, 'EPSG:4326');
+            xyz = center.join(",") + "," + zoom;
+        }
+        return xyz;
     };
 
     /*

--- a/lib/mviewer.js
+++ b/lib/mviewer.js
@@ -1446,7 +1446,7 @@ mviewer = (function () {
                     var xyz = _getLonLatZfromGeometry(geom, 'EPSG:4326', zoom);
                     str += '<li class="fuse list-group-item" data-icon="false" title="' + result_label + '">' +
                         '<a href="#" onclick="mviewer.zoomToLocation('
-                        + xyz + ');">'
+                        + xyz.lon + ',' + xyz.lat + ',' + xyz.zoom + ');">'
                         + result_label + '</a></li>';
                 });
             }
@@ -2377,17 +2377,24 @@ mviewer = (function () {
          */
 
     var _getLonLatZfromGeometry = function (geometry, proj, maxzoom) {
-        var xyz = "";
-        if (geometry.getType === "Point") {
-            xyz = geometry.getCoordinates().join(",") + "," + maxzoom || 15;
+        var xyz = {};
+        if (geometry.getType() === "Point") {
+            var coordinates = geometry.getCoordinates();
+            xyz = { lon: coordinates[0],
+                    lat: coordinates[1],
+                    zoom: maxzoom || 15
+            };
         } else {
             var extent = geometry.getExtent();
-            var projExtent = ol.proj.transformExtent(extent, 'EPSG:4326', _projection.getCode());
+            var projExtent = ol.proj.transformExtent(extent, proj, _projection.getCode());
             var resolution = _map.getView().getResolutionForExtent(projExtent, _map.getSize());
             var zoom = parseInt(_map.getView().getZoomForResolution(resolution));
             if (maxzoom && zoom > maxzoom) { zoom = maxzoom; }
             var center = ol.proj.transform(ol.extent.getCenter(extent),proj, 'EPSG:4326');
-            xyz = center.join(",") + "," + zoom;
+            xyz = { lon: center[0],
+                    lat: center[1],
+                    zoom: zoom
+            };
         }
         return xyz;
     };


### PR DESCRIPTION
Création d'une nouvelle méthode `_getLonLatZfromGeometry.`
Cette méthode calcule le cadrage optimisé pour afin de zoomer sur une entité géographique.
`_getLonLatZfromGeometry` gère 3 paramètres

- la géométrie de l'entité,
- la projection de l'entité,
- le zoom maxi - paramètre optionnel

Fix  #69

