### PR TITLE
Add optional 'tiled' param for WMS base layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,9 @@ Représente les fonds de plan.
 * **label**: Titre du fond de plan
 * **title**: Sous-titre du fond de plan
 * **maxscale**: Echelle max du fond de plan
-* **thumbgallery**: Imagette pour le fond de plan ( dans le cas du style gallery).
+* **thumbgallery**: Imagette pour le fond de plan (dans le cas du style gallery).
 * **url**: Url du service ogc
+* **tiled**: Indique si le paramètre "TILED=true" doit être inséré dans les requêtes WMS (pour des couches disponibles en WMS-C). Valeur par défaut : true.
 * **layers**: Nom de la ressource ogc
 * **format**: Format image du fond de plan 
 * **visible**: Visibilité du fond de plan

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -729,110 +729,113 @@ mviewer = (function () {
         var crossorigin = configuration.getCrossorigin();
         var l;
         switch (baselayer.type) {
-        case "fake":
-            var l = new ol.layer.Base({});
-            _backgroundLayers.push(l);
-            l.set('name', baselayer.label);
-            l.set('blid', baselayer.id);
-            break;
-        case "WMS":
-            l =  new ol.layer.Tile({
-                source: new ol.source.TileWMS({
-                    url: baselayer.url,
-                    crossOrigin: crossorigin,
-                    maxZoom: baselayer.maxzoom || 18,
-                    params: {
-                        'LAYERS': baselayer.layers,
-                        'VERSION': '1.1.1',
-                        'FORMAT': baselayer.format,
-                        'TRANSPARENT': false,
-                        'TILED': true
-                    },
-                    attributions:  baselayer.attribution
-                }),
-                visible: false
-            });
-            l.set('name', baselayer.label);
-            l.set('blid', baselayer.id);
-
-            _backgroundLayers.push(l);
-            _map.addLayer(l);
-            break;
-        case "WMTS":
-            if (baselayer.fromcapacity === "false") {
-                var matrixset = baselayer.matrixset;
-                var projectionExtent = _projection.getExtent();
-                l = new ol.layer.Tile({
-                    source: new ol.source.WMTS({
-                        url:  baselayer.url,
-                        crossOrigin: crossorigin,
-                        layer: baselayer.layers,
-                        matrixSet: matrixset,
-                        style: baselayer.style,
-                        format: baselayer.format,
-                        attributions: baselayer.attribution,
-                        projection: _projection,
-                        tileGrid: new ol.tilegrid.WMTS({
-                            origin: ol.extent.getTopLeft(projectionExtent),
-                            resolutions: utils.getWMTSTileResolutions(matrixset),
-                            matrixIds: utils.getWMTSTileMatrix(matrixset)
-                        })
-                    })
-                });
-                l.setVisible(false);
+            case "fake":
+                l = new ol.layer.Base({});
+                _backgroundLayers.push(l);
                 l.set('name', baselayer.label);
                 l.set('blid', baselayer.id);
-                _map.addLayer(l);
-                _backgroundLayers.push(l);
-            }
-            else {
-                $.ajax({
-                    url:_ajaxURL(baselayer.url),
-                    dataType: "xml",
-                    data: {
-                        SERVICE: "WMTS",
-                        VERSION: "1.0.0",
-                        REQUEST: "GetCapabilities"
-                    },
-                    success: function (xml) {
-                        var getCapabilitiesResult = (new ol.format.WMTSCapabilities()).read(xml);
-                        var WMTSOptions = ol.source.WMTS.optionsFromCapabilities( getCapabilitiesResult, {
-                            layer: baselayer.layers,
-                            matrixSet: baselayer.matrixset,
-                            format:baselayer.format,
-                            style: baselayer.style
-                        });
-                        WMTSOptions.attributions = baselayer.attribution;
-                        l = new ol.layer.Tile({ source: new ol.source.WMTS(WMTSOptions) });
-                        l.set('name', baselayer.label);
-                        l.set('blid', baselayer.id);
-                        _map.getLayers().insertAt(0,l);
-                        _backgroundLayers.push(l);
-                        if( baselayer.visible === 'true' ) {
-                            l.setVisible(true);
-                        } else {
-                            l.setVisible(false);
-                        }
-                    }
+                break;
+            case "WMS":
+                var params = {
+                                'LAYERS': baselayer.layers,
+                                'VERSION': '1.1.1',
+                                'FORMAT': baselayer.format,
+                                'TRANSPARENT': false
+                };
+                if (baselayer.tiled !== "false") {
+                    params.TILED = true;
+                }
+                l =  new ol.layer.Tile({
+                    source: new ol.source.TileWMS({
+                        url: baselayer.url,
+                        crossOrigin: crossorigin,
+                        maxZoom: baselayer.maxzoom || 18,
+                        params: params,
+                        attributions:  baselayer.attribution
+                    }),
+                    visible: false
                 });
-            }
-            break;
+                l.set('name', baselayer.label);
+                l.set('blid', baselayer.id);
 
-        case "OSM":
-            l = new ol.layer.Tile({
-                source: new ol.source.OSM({
-                    url: baselayer.url,
-                    crossOrigin: 'anonymous',
-                    maxZoom: baselayer.maxzoom || 18,
-                    attributions: baselayer.attribution
-                }),
-                visible: false
-            });
-            l.set('name', baselayer.label);
-            l.set('blid', baselayer.id);
-            _backgroundLayers.push(l);
-            _map.addLayer(l);
-            break;
+                _backgroundLayers.push(l);
+                _map.addLayer(l);
+                break;
+            case "WMTS":
+                if (baselayer.fromcapacity === "false") {
+                    var matrixset = baselayer.matrixset;
+                    var projectionExtent = _projection.getExtent();
+                    l = new ol.layer.Tile({
+                        source: new ol.source.WMTS({
+                            url:  baselayer.url,
+                            crossOrigin: crossorigin,
+                            layer: baselayer.layers,
+                            matrixSet: matrixset,
+                            style: baselayer.style,
+                            format: baselayer.format,
+                            attributions: baselayer.attribution,
+                            projection: _projection,
+                            tileGrid: new ol.tilegrid.WMTS({
+                                origin: ol.extent.getTopLeft(projectionExtent),
+                                resolutions: utils.getWMTSTileResolutions(matrixset),
+                                matrixIds: utils.getWMTSTileMatrix(matrixset)
+                            })
+                        })
+                    });
+                    l.setVisible(false);
+                    l.set('name', baselayer.label);
+                    l.set('blid', baselayer.id);
+                    _map.addLayer(l);
+                    _backgroundLayers.push(l);
+                }
+                else {
+                    $.ajax({
+                        url:_ajaxURL(baselayer.url),
+                        dataType: "xml",
+                        data: {
+                            SERVICE: "WMTS",
+                            VERSION: "1.0.0",
+                            REQUEST: "GetCapabilities"
+                        },
+                        success: function (xml) {
+                            var getCapabilitiesResult = (new ol.format.WMTSCapabilities()).read(xml);
+                            var WMTSOptions = ol.source.WMTS.optionsFromCapabilities( getCapabilitiesResult, {
+                                layer: baselayer.layers,
+                                matrixSet: baselayer.matrixset,
+                                format:baselayer.format,
+                                style: baselayer.style
+                            });
+                            WMTSOptions.attributions = baselayer.attribution;
+                            l = new ol.layer.Tile({ source: new ol.source.WMTS(WMTSOptions) });
+                            l.set('name', baselayer.label);
+                            l.set('blid', baselayer.id);
+                            _map.getLayers().insertAt(0,l);
+                            _backgroundLayers.push(l);
+                            if( baselayer.visible === 'true' ) {
+                                l.setVisible(true);
+                            } else {
+                                l.setVisible(false);
+                            }
+                        }
+                    });
+                }
+                break;
+
+            case "OSM":
+                l = new ol.layer.Tile({
+                    source: new ol.source.OSM({
+                        url: baselayer.url,
+                        crossOrigin: 'anonymous',
+                        maxZoom: baselayer.maxzoom || 18,
+                        attributions: baselayer.attribution
+                    }),
+                    visible: false
+                });
+                l.set('name', baselayer.label);
+                l.set('blid', baselayer.id);
+                _backgroundLayers.push(l);
+                _map.addLayer(l);
+                break;
         }
     };
 


### PR DESCRIPTION
L'idée est de corrigé le souci rencontré avec MapProxy dans le ticket suivant :
https://github.com/geobretagne/mviewer/issues/94

Mon commit est pas super lisible.
J'ai essentiellement introduit ces lignes de code dans mviewer.js pour les couches WMS :
                var params = {
                                'LAYERS': baselayer.layers,
                                'VERSION': '1.1.1',
                                'FORMAT': baselayer.format,
                                'TRANSPARENT': false
                };
                if (baselayer.tiled !== "false") {
                    params.TILED = true;
                }
Les applis actuelles vont continuer de fonctionner comme avant.
Cela permet simplement de passer ne mode WMS-C ou pas sans pour autant modifier le fait que les couches WMS sont tuilées.
C'est toujours une couche de type ol.layer.Tile qui est créée.

Le reste c'est essentiellement de l'indentation que j'ai corrigé.
J'ai mis à jour le readme en conséquence.