### PR TITLE
Nouveaux comportements associés au clic sur résultat de recherche

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Options liées à la recherche d'adresse (olscompletion) et à la recherche d'en
 
 #### Prototype
 
-    <searchparameters [bbox=""] [inputlabel=""] [localities=""] [features=""] [static=""]/>
+    <searchparameters [bbox=""] [inputlabel=""] [localities=""] [features=""] [static=""] [querymaponclick=""] [closeafterclick=""]/>
 
 #### Attributs
 
@@ -244,6 +244,8 @@ appliquer à ce type de recherche) ni avec la recherche BAN (cette option donne 
 proximité du centre de la carte mais n'applique pas réellement de filtre géographique).
 * **inputlabel**: Texte à utiliser pour le placeholder de la zone de saisie de la barre de recherche. default = "Rechercher".
 * **localities**: Optional - Utilisation du service d'adresse olscompletion : true ou false - defaut = true
+* **querymaponclick**: Optional - Interroge la carte après sélection d'un résultat : true ou false - defaut = false
+* **closeafterclick**: Optional - Ferme la liste des résultats de recherche après avoir sélectionné un item : true ou false - defaut = false
 * **features**: Optional - Utilisation du service de recherche d'entités (recherches s'appuyant sur Elasticsearch ou 
 Fuse) : true ou false - defaut = true.
 * **static**: Optional - En lien avec le paramètre **doctypes**. Active ou désactive la recherche associée à des 

--- a/demo/ban.xml
+++ b/demo/ban.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config>    
+    <application title="Démo BAN" logo="" help="" showhelp="false" exportpng="false" style="css/themes/carrot.css"/>
+    <mapoptions maxzoom="20" projection="EPSG:3857" center="-292245,6139127" zoom="9" projextent="-20037508.342789244, -20037508.342789244, 20037508.342789244, 20037508.342789244" />
+   	<baselayers style="default">
+        <baselayer  type="OSM" id="positron" label="Positron" title="CartoDb" thumbgallery="img/basemap/positron.png" 
+			url="http://{a-c}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png" maxzoom="20" 
+			visible="true" attribution="Map tiles by  &lt;a href='http://cartodb.com/attributions'>CartoDb &lt;/a>, under  &lt;a href='http://creativecommons.org/licenses/by/3.0/'>CC BY 3.0 &lt;/a>" />
+        <baselayer  type="WMTS" id="ortho1" label="Photo aérienne actuelle" title="GéoBretagne" thumbgallery="img/basemap/ortho.jpg" 
+            url="http://tile.geobretagne.fr/gwc02/service/wmts" layers="satellite" format="image/png" visible="false" 
+            attribution="&lt;a href='http://applications.region-bretagne.fr/geonetwork/?uuid=3a0ac2e3-7af1-4dec-9f36-dae6b5a8c731' target='_blank' >partenaires GéoBretagne - IGN RGE BD ORTHO - PlanetObserver&lt;/a>" style="_null" matrixset="EPSG:3857" fromcapacity="false"/>
+        <baselayer  type="WMS" id="photo2" label="Photo aérienne 1950" title="GéoBretagne" thumbgallery="img/basemap/ortho-ancien.jpg" 
+			url="http://geobretagne.fr/geoserver/photo/wms" layers="satellite-ancien" format="image/jpeg" visible="false" 
+			attribution="&lt;a href='http://applications.region-bretagne.fr/geonetwork/?uuid=048622c5-b333-4c2b-94ec-40a41608dc06' target='_blank' >Partenaires GéoBretagne - IGN&lt;/a>"/>        
+    </baselayers> 
+    <proxy url=""/>
+    <searchparameters localities="true" features="false" bbox="true" querymaponclick="true" closeafterclick="true"/>
+    <olscompletion url="http://api-adresse.data.gouv.fr/search/" type="ban" attribution="La recherche d'adresse est un service proposé par l'API adresse.data.gouv.fr"/>
+    <themes mini="false"> 
+         <theme name="Population"  collapsed="false" id="habitant" icon="fas fa-users">
+    		<layer id="rp_struct_pop_geom" name="Densité de population (hab/km²)"  visible="true" tiled="false"
+		            searchable="false" queryable="true"	                
+	                infoformat="application/vnd.ogc.gml" featurecount="2"
+	                style="rphab_densite@commune"
+                    filter="level='Commune'"
+                    fields="nom_geo,p_pop"
+                    aliases="Nom,Population"
+	                stylesalias=""
+	                url="https://ows.region-bretagne.fr/geoserver/rb/wms"
+	                attribution="Sources: INSEE (RP) - OpenStreetMap | Traitements: Région Bretagne - Service connaissance, observation, planification et prospective" 
+	                metadata="https://kartenn.region-bretagne.fr/geonetwork/?uuid=26324529-e0b7-450c-9506-2dcdca608f5f"
+	                metadata-csw="https://kartenn.region-bretagne.fr/geonetwork/srv/eng/csw?SERVICE=CSW&amp;VERSION=2.0.2&amp;REQUEST=GetRecordById&amp;elementSetName=full&amp;ID=26324529-e0b7-450c-9506-2dcdca608f5f">
+		        </layer>
+		</theme>         
+       </themes>
+</config>

--- a/demo/fuse.xml
+++ b/demo/fuse.xml
@@ -1,7 +1,7 @@
 <config>
     <application title="Démo Fuse" logo="" help="demo/demo_fuse_help.html" showhelp="true" style="css/themes/nephritis.css" exportpng="false" measuretools="false" />
     <mapoptions maxzoom="20" projection="EPSG:3857" center="-307903.74898791354,6141345.088741366" zoom="8" />
-    <searchparameters localities="false" features="true" bbox="false"/>
+    <searchparameters localities="false" features="true" bbox="false" querymaponclick="true" closeafterclick="false"/>
     <elasticsearch url="http://ows.region-bretagne.fr/kartenn/_search" geometryfield="geometry" querymode="match" linkid="search_id" version="1.4"/>
     <baselayers style="default">
         <baselayer  visible="true" type="OSM" id="positron" label="Positron" title="CartoDb" thumbgallery="img/basemap/positron.png" url="http://{a-c}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png" maxzoom="20" attribution="Map tiles by  &lt;a href='http://cartodb.com/attributions'>CartoDb &lt;/a>, under  &lt;a href='http://creativecommons.org/licenses/by/3.0/'>CC BY 3.0 &lt;/a>" /> <baselayer  visible="false" type="WMTS" id="ortho1" label="Photo aérienne actuelle"   title="GéoBretagne" thumbgallery="img/basemap/ortho.jpg" url="http://tile.geobretagne.fr/gwc02/service/wmts"   layers="satellite" format="image/png" style="_null" matrixset="EPSG:3857" fromcapacity="false"   attribution="&lt;a href='http://applications.region-bretagne.fr/geonetwork/?uuid=3a0ac2e3-7af1-4dec-9f36-dae6b5a8c731' target='_blank' >partenaires GéoBretagne - IGN RGE BD ORTHO - PlanetObserver&lt;/a>" />

--- a/js/info.js
+++ b/js/info.js
@@ -148,7 +148,7 @@ var info = (function () {
             var format = new ol.format.GeoJSON();
             _map.forEachFeatureAtPixel(pixel, function(feature, layer) {
                 var l = layer.get('mviewerid');
-                if (l != 'featureoverlay' && l != 'elasticsearch') {
+                if (l && l != 'featureoverlay' && l != 'elasticsearch' ) {
                     var queryable = _overLayers[l].queryable;
                     if (queryable) {
                         if (vectorLayers[l] && vectorLayers[l].features) {
@@ -844,6 +844,7 @@ var info = (function () {
         enabled : enabled,
         toggleTooltipLayer: toggleTooltipLayer,
         queryLayer: queryLayer,
+        queryMap: _queryMap,
         formatHTMLContent: createContentHtml,
         templateHTMLContent: applyTemplate,
         addQueryableLayer: _addQueryableLayer

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -1706,13 +1706,23 @@ mviewer = (function () {
          *
          */
 
-        zoomToLocation: function (x, y, zoom, lib) {
+        zoomToLocation: function (x, y, zoom, querymap) {
             if (_sourceOverlay) {
                 _sourceOverlay.clear();
             }
             var ptResult = ol.proj.transform([x, y], 'EPSG:4326', _projection.getCode());
             _map.getView().setCenter(ptResult);
             _map.getView().setZoom(zoom);
+            if (querymap) {
+                var i = function () {
+                    var e = {
+                        coordinate:ptResult,
+                        pixel: _map.getPixelFromCoordinate(_map.getView().getCenter())
+                    };
+                    info.queryMap(e);
+                };
+                setTimeout(i, 250);
+            }
         },
 
 
@@ -1836,7 +1846,7 @@ mviewer = (function () {
          * Public Method: setLoginInfo
          *
          */
-         
+
         setLoginInfo: function (ctx) {
             var _layer_id = ctx.id.split('#')[1];
             var _service_url = mviewer.getLayers()[_layer_id].url;
@@ -1918,7 +1928,7 @@ mviewer = (function () {
                 if(layer.secure == "layer")
                     view.secure_layer = true;
             }
-            
+
             var item = Mustache.render(mviewer.templates.layerControl, view);
             if (layer.customcontrol && mviewer.customControls[layer.layerid] && mviewer.customControls[layer.layerid].form) {
                 item = $(item).find('.mv-custom-controls').append(mviewer.customControls[layer.layerid].form).closest(".mv-layer-details");

--- a/js/search.js
+++ b/js/search.js
@@ -126,7 +126,7 @@ var search = (function () {
      * Enables properties the search
      */
 
-    var _searchparams = { localities : true, bbox: false, features: false, static: false};
+    var _searchparams = { localities : true, bbox: false, features: false, static: false, querymaponclick:false, closeafterclick:false};
 
      /**
      * Private Method: _clearSearchResults
@@ -147,6 +147,16 @@ var search = (function () {
     var _clearSearchField = function () {
         _clearSearchResults();
         $("#searchfield").val("");
+    };
+
+    var _showResults = function (results) {
+        $("#searchresults").append(results);
+        if (_searchparams.closeafterclick) {
+            $("#searchresults .list-group-item").click(function(){
+                $(".searchresults-title .close").trigger("click");
+            });
+        }
+        $("#searchresults").show();
     };
 
     /**
@@ -232,13 +242,13 @@ var search = (function () {
                                     break;
                                 }
                             str += '<a class="geoportail list-group-item" href="#" onclick="mviewer.zoomToLocation(' +
-                            res[i].x + ',' + res[i].y + ',' + zoom + ',\'' + res[i].fulltext.replace("'", "*") + '\');" '+
+                            res[i].x + ',' + res[i].y + ',' + zoom + ',' + _searchparams.querymaponclick +');" '+
                             'onmouseover="mviewer.flash('+'\'EPSG:4326\',' + res[i].x + ',' + res[i].y + ');"> ' +
                             res[i].fulltext + '</a>';
                         }
                         $(".geoportail").remove()
                         if (res.length > 0) {
-                             $("#searchresults").append(str).show();
+                             _showResults(str);
                         }
                     }
                 });
@@ -284,11 +294,10 @@ var search = (function () {
                             res[i].properties.context+' - ' + res[i].properties.type +
                             '" onclick="mviewer.zoomToLocation('+
                             res[i].geometry.coordinates[0] + ',' +
-                            res[i].geometry.coordinates[1] + ',' + zoom + ',\'' +
-                            res[i].properties.name.replace("'", "*") + '\');">' + res[i].properties.label + '</a>';
+                            res[i].geometry.coordinates[1] + ',' + zoom + ',' + _searchparams.querymaponclick +');">' + res[i].properties.label + '</a>';
                         }
                         $(".geoportail").remove();
-                        $("#searchresults").append(str).show();
+                        _showResults(str);
                     }
                 });
             }
@@ -380,13 +389,13 @@ var search = (function () {
                     var xyz = mviewer.getLonLatZfromGeometry(geom, 'EPSG:4326', zoom);
                     str += '<a class="fuse list-group-item" title="' + result_label + '" ' +
                         'href="#" onclick="mviewer.zoomToLocation('
-                        + xyz.lon + ',' + xyz.lat + ',' + xyz.zoom + ');mviewer.showLocation(\'EPSG:4326\','
+                        + xyz.lon + ',' + xyz.lat + ',' + xyz.zoom + ',' + _searchparams.querymaponclick +');mviewer.showLocation(\'EPSG:4326\','
                         + xyz.lon + ',' + xyz.lat +');" '
                         + 'onmouseover="mviewer.flash(\'EPSG:4326\',' + xyz.lon + ',' + xyz.lat + ');" >'
                         + result_label + '</a>';
                 });
             }
-            $("#searchresults").append(str).show();
+            _showResults(str);
         }
     };
 
@@ -531,7 +540,7 @@ var search = (function () {
                                 _sourceEls.addFeature(feature);
                                 action_over = 'mviewer.showFeature(\'feature.'+i+'\');';
                             } else {
-                                action_click = 'mviewer.zoomToLocation('  + point[0] + ',' + point[1]  + ',14);';
+                                action_click = 'mviewer.zoomToLocation('  + point[0] + ',' + point[1]  + ',14,' + _searchparams.querymaponclick +');';
                                 action_over = 'mviewer.flash('+'\'EPSG:4326\',' + point[0] + ',' + point[1] + ');';
                             }
                             if  (_overLayers[data.hits.hits[i]._type] ) {
@@ -551,7 +560,7 @@ var search = (function () {
                         }
                         $(".elasticsearch").remove();
                         if (nb > 0) {
-                            $("#searchresults").append(str).show();
+                            _showResults(str);
                         }
                     },
                     error: function (xhr, ajaxOptions, thrownError) {
@@ -660,6 +669,8 @@ var search = (function () {
             _searchparams.localities = (configuration.searchparameters.localities === "true");
             _searchparams.features = (configuration.searchparameters.features === "true");
             _searchparams.static = (configuration.searchparameters.static === "true");
+            _searchparams.querymaponclick = (configuration.searchparameters.querymaponclick === "true");
+            _searchparams.closeafterclick = (configuration.searchparameters.closeafterclick === "true");
         }
         if (_searchparams.localities===false && _searchparams.features===false) {
             $("#searchtool").remove();


### PR DESCRIPTION
Création de deux nouveaux paramètres associés à la configuration searchparameters

- `querymaponclick` : pour interroger la carte après avoir sélectionné un des résultats de recherche
- `closeafterclick`: pour fermer la liste des résultats de recherche après avoir cliqué sur un élément.

Fix #158