### PR TITLE
feat config: introduce owsoptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,13 +139,15 @@ Représente les fonds de plan.
 ##### Prototype
 
 
-    <baselayer type="" id="" label="" title="" maxscale="" thumbgallery="" url="" layers="" format="" visible="" fromcapacity=""
+    <baselayer type="" owsoptions="" id="" label="" title="" maxscale="" thumbgallery="" url="" layers="" format="" visible="" fromcapacity=""
     attribution="" style="" matrixset="" maxzoom=""/>
 
 
 ##### Attributs
 
 * **type**: Type de flux OGC (OSM/WMTS/WMS/fake)
+* **owsoptions**: Pour une couche WMS, permet de forcer certains paramètres des requêtes GetMap. Exemple : 
+"VERSION:1.3.0"
 * **id**: Identifiant du fond de plan
 * **label**: Titre du fond de plan
 * **title**: Sous-titre du fond de plan
@@ -302,6 +304,7 @@ Nœud enfant de theme ou group décrivant une couche.
     <layer id="" name="" scalemin="" scalemax="" visible="" tiled=""
     queryable="" fields="" aliases=""
     type=""
+    owsoptions=""
     filter=""
     searchable=""
     searchid=""
@@ -347,6 +350,8 @@ Nœud enfant de theme ou group décrivant une couche.
 * **type**: Type de la couche (wms|geojson|kml|customlayer|csv) default=wms. Si customlayer est défini, il faut instancier
 un Layer OpenLayers dans un fichier javascript ayant pour nom l'id de la couche.
 Ce fichier js doit être placé dans le répertoire customlayers.
+* **owsoptions**: Pour une couche WMS, permet de forcer certains paramètres des requêtes GetMap. Exemple : 
+"VERSION:1.1.1,EXCEPTIONS:application/vnd.ogc.se_inimage"
 * **scalemin**: Echelle minimum de la couche.
 * **scalemax**: Echelle maximum de la couche.
 * **visible**:  Booléen stipulant si la couche est actuellement visible.

--- a/demo/owsoptions.xml
+++ b/demo/owsoptions.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <application title="Démo owsoptions" logo="img/logo/g.png" exportpng="false" style="css/themes/pink.css"/>
+    <mapoptions maxzoom="20" projection="EPSG:3857" center="-198478,6137005" zoom="14" projextent="-20037508.342789244, -20037508.342789244, 20037508.342789244, 20037508.342789244" />
+    <baselayers style="default">
+        <baselayer  type="WMTS" id="ortho1" label="Photo aérienne actuelle" title="GéoBretagne" thumbgallery="img/basemap/ortho.jpg"
+            url="http://tile.geobretagne.fr/gwc02/service/wmts" layers="satellite" format="image/png" visible="false"
+            attribution="&lt;a href='http://applications.region-bretagne.fr/geonetwork/?uuid=3a0ac2e3-7af1-4dec-9f36-dae6b5a8c731' target='_blank' >partenaires GéoBretagne - IGN RGE BD ORTHO - PlanetObserver&lt;/a>" style="_null" matrixset="EPSG:3857" fromcapacity="false"/>
+        <baselayer  type="WMS" id="photo2" label="Photo aérienne 1950" title="GéoBretagne" thumbgallery="img/basemap/ortho-ancien.jpg"
+            url="http://geobretagne.fr/geoserver/photo/wms" layers="satellite-ancien" format="image/jpeg" visible="true"
+            attribution="&lt;a href='http://applications.region-bretagne.fr/geonetwork/?uuid=048622c5-b333-4c2b-94ec-40a41608dc06' target='_blank' >Partenaires GéoBretagne - IGN&lt;/a>"
+            owsoptions="VERSION:1.3.0,EXCEPTIONS:application/vnd.ogc.se_inimage" />
+        <baselayer  type="WMS" id="osm" label="OpenStreetMap" title="Plan OSM Géobretagne" thumbgallery="img/basemap/osm.png"
+            url="http://osm.geobretagne.fr/gwc01/service/wms" layers="osm:google" format="image/png" visible="false"
+            attribution="GéoBretagne. Données : les contributeurs d'&lt;a href='http://www.openstreetmap.org/' target='_blank'>OpenStreetMap &lt;/a>,  &lt;a href='http://www.openstreetmap.org/copyright' target='_blank'>ODbL &lt;/a>"/>
+    </baselayers>
+    <proxy url=""/>
+    <searchparameters localities="false"/>
+    <themes mini="false">
+        <theme name="Randonnée"   id="rando" icon="fas fa-blind">
+            <layer id="pdipr_35" name="PDIPR 35" visible="true" tiled="false"
+                queryable="true" fields="" aliases="" expanded="true"
+                infoformat="text/html" featurecount="1"
+                style="cd35:PDIPR35-Pedestre,cd35:PDIPR35-Equestre"
+                stylesalias="Réseau pédestre,Réseau équestre"
+                attributefilter="true" attributefield="REVET" attributevalues="Terre,Empierré,Goudron"  attributelabel="Revêtement" attributestylesync="false" attributefilterenabled="false"
+                url="https://geobretagne.fr/geoserver/cd35/wms"
+                attribution="GéoBretagne"
+                metadata="https://geobretagne.fr/geonetwork/apps/georchestra/?uuid=075fbf9d-0511-4e99-8bca-fabc13a0cf40"
+                metadata-csw="https://geobretagne.fr/geonetwork/srv/eng/csw?SERVICE=CSW&amp;VERSION=2.0.2&amp;REQUEST=GetRecordById&amp;elementSetName=full&amp;ID=075fbf9d-0511-4e99-8bca-fabc13a0cf40"
+                owsoptions="TILED:FALSE" />
+        </theme>
+        <theme name="Supervision"  collapsed="true" id="hydrometrie" icon="fas fa-chart-line">
+            <layer id="hydrometrie_stations_technique" name="Supervision du réseau hydro." visible="true" tiled="true"
+                queryable="true" fields="" aliases=""
+                infoformat="text/html" featurecount="1"
+                style=""
+                url="https://geobretagne.fr/geoserver/dreal_b/wms"
+                attribution="GéoBretagne"
+                metadata="https://geobretagne.fr/geonetwork/apps/georchestra/?uuid=34d15ff0-ac1c-48d9-a9bd-a38d60fa0ecc"
+                metadata-csw="https://geobretagne.fr/geonetwork/srv/eng/csw?SERVICE=CSW&amp;VERSION=2.0.2&amp;REQUEST=GetRecordById&amp;elementSetName=full&amp;ID=34d15ff0-ac1c-48d9-a9bd-a38d60fa0ecc"
+                owsoptions="VERSION:1.1.1,EXCEPTIONS:application/vnd.ogc.se_inimage" />
+        </theme>
+    </themes>
+</config>

--- a/index.html
+++ b/index.html
@@ -86,6 +86,7 @@
     <script type="text/javascript" src="lib/fuse/fuse.min.js"></script>
     <script type="text/javascript" src="js/extend.js"></script>
     <script type="text/javascript" src="js/utils.js"></script>
+    <script type="text/javascript" src="js/ogcutils.js"></script>
     <script type="text/javascript" src="js/configuration.js"></script>
     <script type="text/javascript" type="text/javascript" src="js/measure.js"></script>
     <script type="text/javascript" type="text/javascript" src="js/info.js"></script>

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -428,15 +428,13 @@ var configuration = (function () {
                     layerRank+=1;
                     var layerId = layer.id;
                     if (layer.url) {
-                        var layerUrl = layer.url.replace(/[?&]$/, '');
-                        var capabilitiesParams = "REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.3.0";
-                        var getCapUrl = layerUrl.indexOf('?') === -1 ? layerUrl + '?' + capabilitiesParams : layerUrl + '&' + capabilitiesParams;
+                        var getCapRequestUrl = getCapUrl(layer.url);
                         var secureLayer = (layer.secure === "true" || layer.secure == "global") ? true : false;
                         if (secureLayer) {
                             $.ajax({
                                 dataType: "xml",
                                 layer: layerId,
-                                url:  mviewer.ajaxURL(getCapUrl),
+                                url:  mviewer.ajaxURL(getCapRequestUrl),
                                 success: function (result) {
                                     //Find layer in capabilities
                                     var name = this.layer;
@@ -656,7 +654,7 @@ var configuration = (function () {
                     if (oLayer.type === 'wms') {
                         var wms_params = {
                             'LAYERS': layer.id,
-                            'STYLES':(themeLayers[oLayer.id].style)? themeLayers[oLayer.id].style : '',
+                            'STYLES': (themeLayers[oLayer.id].style)? themeLayers[oLayer.id].style : '',
                             'FORMAT': 'image/png',
                             'TRANSPARENT': true
                         };
@@ -671,6 +669,10 @@ var configuration = (function () {
                         if (oLayer.sld) {
                             wms_params['SLD'] = oLayer.sld;
                         }
+
+                        // Use owsoptions to overload default Getmap params
+                        Object.assign(wms_params, getParamsFromOwsOptionsString(layer.owsoptions));
+
                         switch (oLayer.tiled) {
                             case true:
                                 wms_params['TILED'] = true;

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -324,9 +324,9 @@ mviewer = (function () {
 
     var _getlegendurl = function (layer, scale) {
         var legendUrl = "";
-        if (layer.legendurl && !layer.style) {
+        if (layer.legendurl && !layer.styles) {
             legendUrl = layer.legendurl;
-        } else if (layer.legendurl && layer.style && (layer.style.split(",").length === 1)) {
+        } else if (layer.legendurl && layer.styles && (layer.styles.split(",").length === 1)) {
             legendUrl = layer.legendurl;
         } else {
             var getLegendParams = {

--- a/js/ogcutils.js
+++ b/js/ogcutils.js
@@ -1,0 +1,92 @@
+// This function has been mainly copied from appendParams from OpenLayers
+function appendParams(uri, params) {
+  const keyParams = [];
+  // Skip any null or undefined parameter values
+  Object.keys(params).forEach(function(k) {
+    if (params[k] !== null && params[k] !== undefined) {
+      keyParams.push(k + '=' + params[k]);
+    }
+  });
+  const qs = keyParams.join('&');
+  // remove any trailing ? or &
+  uri = uri.replace(/[?&]$/, '');
+  // append ? or & depending on whether uri has existing parameters
+  uri = uri.indexOf('?') === -1 ? uri + '?' : uri + '&';
+  return uri + qs;
+}
+
+function getParamsFromOwsOptionsString(owsOptionsString) {
+    if (owsOptionsString === undefined) {
+      return undefined;
+    }
+
+    var params = {};
+    var kvArray = owsOptionsString.split(",")
+
+    kvArray.forEach( function (kv) {
+        if (kv.includes(":")) {
+            var [key, value] = kv.split(":");
+            if (key !== "") {
+                params[key] = value;
+            }
+        }
+    });
+
+    return params;
+}
+
+function getCapUrl(serviceUri, params) {
+    if (serviceUri === undefined) {
+      return undefined;
+    }
+
+    // transform to uppercase param keys
+    var uppercaseParams = {};
+    for (var key in params) {
+        var upperKey = key.toUpperCase();
+        uppercaseParams[ upperKey ] = params[key];
+    }
+
+    const defaultParams = {
+      'SERVICE': 'WMS',
+      'VERSION': '1.3.0',
+      'REQUEST': 'GetCapabilities',
+    };
+
+    if (params !== undefined) {
+        Object.assign(defaultParams, uppercaseParams);
+    }
+
+    return appendParams(serviceUri, defaultParams);
+}
+
+function getLegendGraphicUrl(serviceUri, params) {
+    if (serviceUri === undefined) {
+      return undefined;
+    }
+
+    // transform to uppercase param keys
+    var uppercaseParams = {};
+    for (var key in params) {
+        var upperKey = key.toUpperCase();
+        uppercaseParams[ upperKey ] = params[key];
+    }
+
+    const defaultParams = {
+      'SERVICE': 'WMS',
+      'VERSION': '1.3.0',
+      'REQUEST': 'GetLegendGraphic',
+      'SLD_VERSION': '1.1.0',
+      'FORMAT': encodeURIComponent('image/png'),
+      'WIDTH': '30',
+      'HEIGHT': '20',
+      'LEGEND_OPTIONS': encodeURIComponent('fontName:Open Sans;fontAntiAliasing:true;fontColor:0x777777;fontSize:10;dpi:96'),
+      'TRANSPARENT': true
+    };
+
+    if (params !== undefined) {
+        Object.assign(defaultParams, uppercaseParams);
+    }
+
+    return appendParams(serviceUri, defaultParams);
+}


### PR DESCRIPTION
Pull request répondant au besoin du ticket #94.

Au passage, j'ai créé un fichier ogcutils.js pour factoriser certaines manipulations courantes avec les services OGC. J'en ai profité pour revoir la fonction _getlegendurl qui me paraissait bancale.

J'ai créé un exemple dans le répertoire demo (owsoptions.xml) dans lequel j'utilise le paramètre owsoptions pour une baselayer et pour 2 couches thématiques. C'est une variation du fichier geobretagne.xml.

J'ai mis à jour également le fichier README en conséquence.
