### PR TITLE
Fix measure area tooltip

### DIFF
--- a/js/measure.js
+++ b/js/measure.js
@@ -179,7 +179,7 @@ var measure = (function () {
     var _measureFormatArea = function(polygon) {
         var area = Math.abs(_wgs84Sphere.getArea(polygon));
         var output;
-        if (area <= 0) {
+        if (area < 0.0001) {
             output = 0;
         } else if (area < 10000) {
             output = (Math.round(area * 100) / 100) + ' ' + 'm<sup>2</sup>';

--- a/js/measure.js
+++ b/js/measure.js
@@ -292,7 +292,13 @@ var measure = (function () {
                 var output;
                 if (geom instanceof ol.geom.Polygon) {
                     output = _measureFormatArea(/** @type {ol.geom.Polygon} */ (geom));
-                    tooltipCoord = geom.getInteriorPoint().getCoordinates();
+                    var coords = geom.getCoordinates()[0];
+                    var nbCoords = coords.length;
+                    if (nbCoords < 2) {
+                        tooltipCoord = coords[0];
+                    } else {
+                        tooltipCoord = coords[nbCoords-2];
+                    }
                 } else if (geom instanceof ol.geom.LineString) {
                     output = _measureFormatLength( /** @type {ol.geom.LineString} */ (geom));
                     tooltipCoord = geom.getLastCoordinate();


### PR DESCRIPTION
Traitement du ticket suivant : #67.
En passant, j'ai également modifié le texte affiché dans l'infobulle quand on a juste 1 ou 2 points dans le polygone : l'infobulle hésitait entre afficher 0 et 0m2. J'ai forcé à afficher 0 lorsque la surface est inférieure à 0.0001.