### PR TITLE
Fix fuse index 185

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -618,10 +618,15 @@ var search = (function () {
 
                             features.forEach(function(feature) {
                                 var geojsonFeature = geojsonFormat.writeFeatureObject(feature);
-                                var wgs84Geom = feature.getGeometry().clone().transform(mapProj, "EPSG:4326");
                                 var prop = geojsonFeature.properties;
-                                prop.geometry = geojsonFormat.writeGeometryObject(wgs84Geom);
-                                prop.fusesearchresult = oLayer.fusesearchresult;
+                                if (feature.getGeometry()) {
+                                    var wgs84Geom = feature.getGeometry().clone().transform(mapProj, "EPSG:4326");
+                                    prop.geometry = geojsonFormat.writeGeometryObject(wgs84Geom);
+                                    prop.fusesearchresult = oLayer.fusesearchresult;
+                                } else {
+                                    console.log("The following feature could not be indexed due to lack of geometry: ",
+                                        prop);
+                                }
                                 j.push(prop);
                             });
 


### PR DESCRIPTION
Ajout d'un test sur la géométrie des objets à indexer :
- évite que le code plante
- indique dans la console les objets en erreur
cf. #185.