### PR TITLE
Fix permalink creation when the current URL contains a fragment

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,9 @@ $(document).ready(function () {
         configFile = "config.xml";
     }
 
+    // Save the config file path in the API object
+    API.config = configFile;
+
     var theme = (API.theme) ? API.theme : null;
 
     $.ajax({

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -1753,7 +1753,7 @@ mviewer = (function () {
             // get xml config file
             var configFile = API.config ? API.config : 'config.xml';
             // get domain url and clean
-            var splitStr = window.location.href.split('?')[0].replace('#','').split('/');
+            var splitStr = window.location.href.split('?')[0].split('#')[0].split('/');
             splitStr = splitStr.slice(0,splitStr.length-1).join('/');
             // create absolute config file url
             var url = splitStr + '/' + configFile;
@@ -1789,7 +1789,7 @@ mviewer = (function () {
             }
             linkParams.mode = $('input[name=mv-display-mode]:checked').val();
 
-            var url = window.location.href.split('?')[0].replace('#','') + '?' + $.param(linkParams);
+            var url = window.location.href.split('#')[0].split('?')[0] + '?' + $.param(linkParams);
             $("#permalinklink").attr('href',url).attr("target", "_blank");
             $("#permaqr").attr("src","http://chart.apis.google.com/chart?cht=qr&chs=140x140&chl=" + encodeURIComponent(url));
             return url;


### PR DESCRIPTION
Fix for #177 issue.
Share a permalink with a map opened with a fragment in the url (#config) now works correctly.