### PR TITLE
[GetFeatureInfo] Add key_value and serialized access to feature fields...

### DIFF
--- a/js/info.js
+++ b/js/info.js
@@ -674,6 +674,27 @@ var info = (function () {
             if (activeAttributeValue) {
                 feature.properties[activeAttributeValue] = true;
             }
+            // add a key_value array with all the fields, allowing to iterate through all fields in a mustache templaye
+            feature.properties['fields_kv'] = function () {
+              fields_kv = [];
+              keys = Object.keys(this);
+              for (i = 0 ; i < keys.length ; i++ ) {
+                if (keys[i] == "fields_kv") {
+                  continue;
+                }
+                field_kv = {
+                  'key': keys[i],
+                  'value': this[keys[i]]
+                }
+                fields_kv.push(field_kv);
+              }
+              return fields_kv;
+            }
+            // add a serialized version of the object so it can easily be passed through HTML GET request
+            // you can deserialize it with `JSON.parse(data)` when data is the serialized data
+            feature.properties['serialized'] = function () {
+              return encodeURIComponent(JSON.stringify(feature.properties));
+            }
             obj.features.push(feature.properties);
         });
         var rendered = Mustache.render(tpl, obj);

--- a/js/info.js
+++ b/js/info.js
@@ -679,7 +679,7 @@ var info = (function () {
               fields_kv = [];
               keys = Object.keys(this);
               for (i = 0 ; i < keys.length ; i++ ) {
-                if (keys[i] == "fields_kv") {
+                if (keys[i] == "fields_kv" || keys[i] == "serialized") {
                   continue;
                 }
                 field_kv = {


### PR DESCRIPTION
...in the mustache templates, allowing to iterate through the fields without the need to know the keys values or hardcode them, e.g.
```
<script>
	{{#fields_kv}}
		console.log("{{key}}: {{value}}")
	{{/fields_kv}}

	console.log("{{serialized}}")
</script>
```
fields_kv and serialized attributes are [function generators](https://github.com/janl/mustache.js#functions), so it doesn't consume resources while you don't use them

Solves #205 