### PR TITLE
Fix Affichage des couches réordonnées #229 + Fix légende vectorielle #219

### DIFF
--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -1743,7 +1743,7 @@ mviewer = (function () {
                 if (actionMove.action === "up") {
                     newIndex = refIndex +1;
                 } else {
-                    newIndex = refIndex -1;
+                    newIndex = refIndex;
                 }
                 layers.splice(newIndex, 0, layers.splice(oldIndex, 1)[0]);
                 //put overlayFeatureLayer on the top of the map

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -370,12 +370,14 @@ mviewer = (function () {
             var marginTop = 15;
             var marginLeft = 15;
             var itemHeight = 20;
-            var horizontalSpace = 10;
+            var textAlign = "Middle";
+            var textBaseline = "End";
             verticalPosition = 0;
             var geomWidth = 25;
             var geomHeight = 15;
             var verticalSpace = itemHeight - geomHeight;
             var ctx = canvas.getContext('2d');
+            var fontsize = 12;
             vectorContext = ol.render.toContext(ctx, {
                 size: [250, (items.length * itemHeight) + marginTop]
             });
@@ -387,7 +389,6 @@ mviewer = (function () {
                         geometry = new ol.geom.Point([marginLeft + (geomWidth/2),
                             verticalPosition - (geomHeight/2)]);
                         break;
-
                     case 'LineString':
                         geometry = new ol.geom.LineString([[marginLeft, -marginTop + verticalPosition],
                             [marginLeft + geomWidth, -marginTop + verticalPosition + geomHeight]]);
@@ -404,15 +405,19 @@ mviewer = (function () {
                 }
 
                 item.styles.forEach(function (style) {
-                    vectorContext.setStyle(style);
+                    let stl = style.clone();
+                    stl.setText(new ol.style.Text({
+                        textAlign: textAlign,
+                        textBaseline: textBaseline,
+                        font: fontsize+"px roboto_regular, Arial, Sans-serif",
+                        text: item.label,
+                        fill: new ol.style.Fill({color: "rgba(153, 153, 153, 1)"}),
+                        offsetX: geomWidth,
+                        offsetY: verticalSpace
+                    }));
+                    vectorContext.setStyle(stl);
                     vectorContext.drawGeometry(geometry);
                 });
-                ctx.fillStyle = 'rgba(153, 153, 153, 1)';
-                var fontsize = 12;
-                ctx.font = fontsize + 'px roboto_regular, Arial, Sans-serif';
-                ctx.textAlign = "left";
-                ctx.fillText(item.label ,marginLeft + geomWidth + horizontalSpace, verticalPosition - (geomHeight - fontsize));
-
             });
         }
     };


### PR DESCRIPTION
#229
Le problème venait de l'utilisation de la fonction splice qui insère un élement à une position x tout en décalant l'élément (qui est à cette position  x) à la position x+1. Donc enlever 1 à x positionnait au bout d'un moment l'élément à la position 0 ce qui décalait le fond de carte à la position 1 .

#219 
J'ai supprimé la partie où l'on dessine le texte dans le canvas puis j'ai ajouté un texte au style de chaque élement de la légende ce qui me permet de dessiner une seule entité (geometry) au lieu de deux (geometry + texte).