### PR TITLE
legendmini param

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,9 @@ Nœud regroupant les couches par thèmes et sous-thèmes.
 
 #### Attributs
 
-* **mini**: Booléen qui précise si le panneau de gauche est réduit à l'ouverture de l'application. Défaut = false.
+* **mini**: Booléen qui précise si le panneau de gauche est réduit à l'ouverture de l'application. Les attributs "collapsed" des <theme> doivent être à false pour que cet attribut soit pris en compte. Défaut = false.
+
+* **legendmini**: Booleén qui précise si le panneau de la légende est réduit à l'ouverture de l'application. Défaut = true.
 
 ### Nœud(s) enfant(s) theme
 

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -790,10 +790,16 @@ mviewer = (function () {
             htmlListGroup += _renderHTMLFromTemplate(mviewer.templates.theme, view);
         });
         var panelMini = configuration.getConfiguration().themes.mini;
+        var legendMini = configuration.getConfiguration().themes.legendmini;
         if (panelMini && (panelMini === 'true')) {
+            // hide all panels
             mviewer.toggleMenu(false);
             mviewer.toggleLegend(false);
         }
+        if(legendMini && (legendMini === "true")) {
+            // hide legend panel
+            mviewer.toggleLegend(false);
+        }        
         $("#menu").html(htmlListGroup);
         initMenu();
         // Open theme item if set to collapsed=false


### PR DESCRIPTION
Fix #216.

Permet d'afficher la le panneau de légende avec un panneau de couches en mode "mini".
Fonctionnement testé sans le paramètre "legendmini" pour rester compatible avec des versions antécédente.

Evolution financée par l'[ARS](https://www.iledefrance.ars.sante.fr/) Île-de-France et du [GCS-SESAN](http://www.sesan.fr/).