### PR TITLE
Update config_layers.rst

### DIFF
--- a/docs/doc_tech/config_layers.rst
+++ b/docs/doc_tech/config_layers.rst
@@ -71,8 +71,8 @@ Elément enfant de ``<theme>`` ou ``<group>``
                 tooltipenabled=""
                 expanded=""
                 metadata=""
-                metadata-csw="" />
-                <template url=""/>
+                metadata-csw="" >
+                <template url=""></template>
         </layer>
 
 Paramètres pour une configuration minimaliste


### PR DESCRIPTION
If I'm not wrong (I compared with the `default.xml` configuration file) there was two typos since :
- it should be `>` instead of `/>` at the end of the (first part of the) `<layer` balise
- And same for the `<template>`