### PR TITLE
Change gh action build strategy (#320)

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,5 +1,9 @@
 on:
-    - push
+  push:
+    branches:
+    - master
+  release:
+    types: [published]
 
 jobs:
   docker-build:


### PR DESCRIPTION
Only run the CI when push on master (which updates the "latest" tagged image), or when a release is made.

See #320

Tests: Untested ! I used the github web-based Actions editor, it should be valid though.