### PR TITLE
Use nginx alpine version for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.17
+FROM nginx:alpine
 
 VOLUME ["/usr/share/nginx/html/apps"]
 


### PR DESCRIPTION
alpine version is sufficient.

Image size drops from 92 to 51 Mb
BTW, I'm not convinced we need to stick to a version number