### PR TITLE
Highlights features with geometry for info tool

### DIFF
--- a/customlayers/cluster.js
+++ b/customlayers/cluster.js
@@ -82,20 +82,14 @@
 
     });
     cl.handle = function(clusters, views) {
-        if (clusters.length > 0 && clusters[0].properties.features) {
-            var features = clusters[0].properties.features;
-            var elements = [];
+        if (clusters.length > 0 && clusters[0].getProperties().features) {
+            var features = clusters[0].getProperties().features;
             var l = mviewer.getLayer("cluster");
-            features.forEach(function(feature, i) {
-                elements.push({
-                    properties: feature.getProperties()
-                });
-            });
             var html;
             if (l.template) {
-                html = info.templateHTMLContent(elements, l);
+                html = info.templateHTMLContent(features, l);
             } else {
-                html = info.formatHTMLContent(elements, l);
+                html = info.formatHTMLContent(features, l);
             }
             var panel = "";
             if (configuration.getConfiguration().mobile) {

--- a/customlayers/inventaire.js
+++ b/customlayers/inventaire.js
@@ -242,8 +242,8 @@ mviewer.customLayers.inventaire = (function () {
         style: _clusterStyle
     });
     var _handle = function(clusters, views) {
-        if (clusters.length > 0 && clusters[0].properties.features) {
-        var features = clusters[0].properties.features;
+        if (clusters.length > 0 && clusters[0].getProperties().features) {
+        var features = clusters[0].getProperties().features;
             var extraTemplate = [
                 '{{#lien_image}}',
                 '<img src="{{lien_image}}" class="img-responsive center-block" />',
@@ -290,13 +290,13 @@ mviewer.customLayers.inventaire = (function () {
 
             };
 
-            var _renderHTML = function (elements) {
+            var _renderHTML = function (features) {
                 var l = mviewer.getLayer("inventaire");
                 var html;
                 if (l.template) {
-                    html = info.templateHTMLContent(elements, l);
+                    html = info.templateHTMLContent(features, l);
                 } else {
-                    html = info.formatHTMLContent(elements, l);
+                    html = info.formatHTMLContent(features, l);
                 }
                 var view = views["right-panel"];
                 view.layers.push({
@@ -313,7 +313,6 @@ mviewer.customLayers.inventaire = (function () {
             // Get additional infos via wfs for each feature
             var search_ids = [];
             var featuretypes = [];
-            var elements = [];
 
             features.forEach(function(feature, i) {
                 if (feature.getProperties() && feature.getProperties().search_id && i < _maxrequestedfeatures) {
@@ -321,9 +320,6 @@ mviewer.customLayers.inventaire = (function () {
                     if (featuretypes.indexOf(feature.getProperties().type) === -1) {
                         featuretypes.push(feature.getProperties().type);
                     }
-                    elements.push({
-                        properties: feature.getProperties()
-                    });
                 }
             });
 
@@ -352,7 +348,7 @@ mviewer.customLayers.inventaire = (function () {
                     }
                 });
             }
-            _renderHTML(elements);
+            _renderHTML(features);
         }
     };
 

--- a/demo/cad/layer.js
+++ b/demo/cad/layer.js
@@ -27,7 +27,7 @@ mviewer.customLayers.cad = (function () {
         let cad_control = mviewer.customControls.cad;
         let src = _layer.getSource();
         src.getFeatures().every(function(feature){
-            if(feature.get("geo_parcelle")===features[0].properties.geo_parcelle){
+            if(feature.get("geo_parcelle")===features[0].getProperties().geo_parcelle){
                 if(cad_control.editSelectedParcelle())
                 {
                     cad_control.editSelectedParcelle().setStyle(_defaultStyle);

--- a/demo/lycee_resultat_bac.mst
+++ b/demo/lycee_resultat_bac.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li id="{{feature_id}}" class="item" style="padding-bottom:65px;">		
+	<li id="{{feature_ol_uid}}" class="item" style="padding-bottom:65px;">		
 		<div class="title-feature" style="padding-top:10px;">{{nom}}</div>
 		<h4><select onchange="drawCharts(this.value);">					
     			<option>2017</option>

--- a/demo/lycee_resultat_bac.mst
+++ b/demo/lycee_resultat_bac.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li class="item" style="padding-bottom:65px;">		
+	<li id="{{feature_id}}" class="item" style="padding-bottom:65px;">		
 		<div class="title-feature" style="padding-top:10px;">{{nom}}</div>
 		<h4><select onchange="drawCharts(this.value);">					
     			<option>2017</option>

--- a/docs/doc_tech/config_layers.rst
+++ b/docs/doc_tech/config_layers.rst
@@ -39,6 +39,7 @@ Elément enfant de ``<theme>`` ou ``<group>``
                 toplayer=""
                 exclusive=""
                 infoformat=""
+                infohighlight=""
                 featurecount=""
                 style=""
                 stylesalias=""
@@ -117,7 +118,8 @@ Paramètres pour gérer l'interrogation et la mise en forme de la fiche d'interr
 
 * ``queryable`` :guilabel:`studio` : Booléen stipulant est ce que la couche est intérrogeable via un GetFeatureInfo
 * ``infoformat`` :guilabel:`studio` : Format du GetFeatureInfo. 2 formats sont supportés : text/html et application/vnd.ogc.gml
-* ``featurecount`` :guilabel:`studio` : Nombre d'éléments retournés lors de l'intérrogation
+* ``infohighlight`` : Booléen précisant si les features de la couche sont mises en surbrillance en interrogeant leurs informations, défaut = true. Si false un markeur est affiché. 
+* ``featurecount`` :guilabel:`studio` : Nombre d'éléments retournés lors de l'interrogation
 * ``fields`` :guilabel:`studio` :  Si les informations retournées par l'interrogation est au format GML, fields représente les attributs à parser pour générer la vignette
 * ``aliases`` :guilabel:`studio` : Si les informations retournées par l'interrogation est au format GML, aliases représente le renommage des champs parsés.
 
@@ -149,7 +151,7 @@ Paramètres pour les couches non WMS
 	``tooltipcontent="{name}} &lt;/br&gt; {{city}}"``
 
 * ``vectorlegend`` : Booléen précisant si la légende pour les couches de type vecteur (customlayer ou csv) est dynamiquement créée
-* ``nohighlight`` : Booléen précisant, pour les couches de type vecteur (customlayer, geojson ou csv), si la mise en surbrillance est désactivée
+* ``nohighlight`` : Booléen précisant, pour les couches de type vecteur (customlayer, geojson ou csv), si la mise en surbrillance du hover est désactivée
 
 Paramètres pour gérer la dimension temporelle des couches WMS
 ================================================================

--- a/docs/doc_tech/config_tpl.rst
+++ b/docs/doc_tech/config_tpl.rst
@@ -21,7 +21,7 @@ Exemple de template structuré
 
 
         {{#features}}
-            <li class="item">
+            <li id="{{feature_id}}" class="item">
                 Exemple de formatage
                 <h3 class="title-feature">{{nom}}</h3>
                 <img src="{{image}}" class="img-responsive" style="margin-top:5%;" /><br/>
@@ -71,7 +71,8 @@ Exemple de template structuré
 Les éléments en rouge sont obligatoires.
 
 Explications : ``{{#features}}{{/features}}`` est une boucle effectuée sur chaque entité présente dans la couche sélectionnée.
-``<li class="item"></li>`` est une entrée de liste html utilisée par le mviewer. S'il y a plusieurs entrées de liste car plusieurs entités sélectionnées, le mviewer présentera les réponses sous la forme d'un carousel.
+``<li id="{{feature_id}}" class="item"></li>`` est une entrée de liste html utilisée par le mviewer. S'il y a plusieurs entrées de liste car plusieurs entités sélectionnées, le mviewer présentera les réponses sous la forme d'un carousel.
+Pour synchroniser le carousel et la sous-sélection sur la carte lors d'un clic, la ``feature_id`` est requise comme ``id`` de la balise.  
 
 Ce qu'il faut savoir de Mustache
 --------------------------------
@@ -116,7 +117,7 @@ Par exemple, ce code :
        :linenos:
 
        {{#features}}
-         <li class="item" style="width:238px;">
+         <li id="{{feature_id}}" class="item" style="width:238px;">
              <ul>
                {{#fields_kv}}
                  <li>{{key}} : {{value}}</li>

--- a/docs/doc_tech/config_tpl.rst
+++ b/docs/doc_tech/config_tpl.rst
@@ -21,7 +21,7 @@ Exemple de template structuré
 
 
         {{#features}}
-            <li id="{{feature_id}}" class="item">
+            <li id="{{feature_ol_uid}}" class="item">
                 Exemple de formatage
                 <h3 class="title-feature">{{nom}}</h3>
                 <img src="{{image}}" class="img-responsive" style="margin-top:5%;" /><br/>
@@ -71,8 +71,9 @@ Exemple de template structuré
 Les éléments en rouge sont obligatoires.
 
 Explications : ``{{#features}}{{/features}}`` est une boucle effectuée sur chaque entité présente dans la couche sélectionnée.
-``<li id="{{feature_id}}" class="item"></li>`` est une entrée de liste html utilisée par le mviewer. S'il y a plusieurs entrées de liste car plusieurs entités sélectionnées, le mviewer présentera les réponses sous la forme d'un carousel.
-Pour synchroniser le carousel et la sous-sélection sur la carte lors d'un clic, la ``feature_id`` est requise comme ``id`` de la balise.  
+``<li id="{{feature_ol_uid}}" class="item"></li>`` est une entrée de liste html utilisée par le mviewer. S'il y a plusieurs entrées de liste car plusieurs entités sélectionnées, le mviewer présentera les réponses sous la forme d'un carousel.
+Pour synchroniser le carousel et la sous-sélection sur la carte lors d'un clic, l'injection de la ``feature_ol_uid`` est requise dans l' ``id`` de la balise. 
+Puisque une ``feature id`` n'est pas obligatoire comme attribut pour une feature l' ``ol_uid`` interne d'OpenLayers est utilisée à ce propos.
 
 Ce qu'il faut savoir de Mustache
 --------------------------------
@@ -117,7 +118,7 @@ Par exemple, ce code :
        :linenos:
 
        {{#features}}
-         <li id="{{feature_id}}" class="item" style="width:238px;">
+         <li id="{{feature_ol_uid}}" class="item" style="width:238px;">
              <ul>
                {{#fields_kv}}
                  <li>{{key}} : {{value}}</li>

--- a/index.html
+++ b/index.html
@@ -582,7 +582,7 @@
                   }
             });
 
-            $("#right-panel .close,#bottom-panel .mv-close").click(function () {mviewer.hideSelectOverlay()});
+            $("#right-panel .close,#bottom-panel .mv-close").click(function () {mviewer.hideLocation()});
 
         });
         </script>

--- a/index.html
+++ b/index.html
@@ -582,7 +582,7 @@
                   }
             });
 
-            $("#right-panel .close,#bottom-panel .mv-close").click(function () {mviewer.hideLocation()});
+            $("#right-panel .close,#bottom-panel .mv-close").click(function () {mviewer.hideSelectOverlay()});
 
         });
         </script>

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -629,6 +629,7 @@ var configuration = (function () {
                     oLayer.dynamiclegend = (layer.dynamiclegend === "true") ? true : false;
                     oLayer.vectorlegend =  (layer.vectorlegend === "true") ? true : false;
                     oLayer.nohighlight =  (layer.nohighlight === "true") ? true : false;
+                    oLayer.infohighlight =  (layer.infohighlight === "false") ? false : true;
                     if (layer.geocodingfields) {
                         oLayer.geocodingfields = layer.geocodingfields.split(",");
                     }

--- a/js/featurestyles.js
+++ b/js/featurestyles.js
@@ -50,43 +50,44 @@ mviewer.featureStyles.circle1 = new ol.style.Style({
     })
 });
 
-var _selectFillColor = 'rgba(82, 98, 217, 0.5)';
-var _selectStrokeColor = 'rgba(82, 98, 217, 1)';
+var getSelectStyle = function(rgb, width, feature) {
 
-var _highlightSelect = {
-    'Point': new ol.style.Style({
-      image: new ol.style.Circle({
-        radius: 7,
+    var _selectFillColor = `rgba(${rgb}, 0.5)`;
+    var _selectStrokeColor = `rgba(${rgb}, 1)`;
+
+    var _highlightSelect = {
+        'Point': new ol.style.Style({
+        image: new ol.style.Circle({
+            radius: 7,
+            fill: new ol.style.Fill({
+            color: _selectFillColor
+            }),
+            stroke: new ol.style.Stroke({
+            color: _selectStrokeColor,
+            width: width
+            })
+        })
+        }),
+        'LineString': new ol.style.Style({
+        stroke: new ol.style.Stroke({
+            color: _selectStrokeColor,
+            width: width
+        })
+        }),
+        'Polygon': new ol.style.Style({
         fill: new ol.style.Fill({
-          color: _selectFillColor
+            color: _selectFillColor
         }),
         stroke: new ol.style.Stroke({
-          color: _selectStrokeColor,
-          width: 2
+            color: _selectStrokeColor,
+            width: width
         })
-      })
-    }),
-    'LineString': new ol.style.Style({
-      stroke: new ol.style.Stroke({
-        color: _selectStrokeColor,
-        width: 4
-      })
-    }),
-    'Polygon': new ol.style.Style({
-      fill: new ol.style.Fill({
-        color: _selectFillColor
-      }),
-      stroke: new ol.style.Stroke({
-        color: _selectStrokeColor,
-        width: 4
-      })
-    })
-};
-_highlightSelect['MultiPoint'] = _highlightSelect['Point'];
-_highlightSelect['MultiLineString'] = _highlightSelect['LineString'];
-_highlightSelect['MultiPolygon'] = _highlightSelect['Polygon'];
+        })
+    };
+    _highlightSelect['MultiPoint'] = _highlightSelect['Point'];
+    _highlightSelect['MultiLineString'] = _highlightSelect['LineString'];
+    _highlightSelect['MultiPolygon'] = _highlightSelect['Polygon'];
 
-var getSelectStyle = function(feature) {
     return _highlightSelect[feature.getGeometry().getType()];
 }
 

--- a/js/featurestyles.js
+++ b/js/featurestyles.js
@@ -33,8 +33,8 @@ mviewer.featureStyles.crossStyle = new ol.style.Style({
 });
 
 mviewer.featureStyles.highlight = new ol.style.Style({
-  fill: new ol.style.Fill({color: 'rgba(212, 53, 50,0)'}),
-  stroke: new ol.style.Stroke({color: 'rgba(217, 85, 82,1)', width: 4})
+    fill: new ol.style.Fill({color: 'rgba(212, 53, 50,0)'}),
+    stroke: new ol.style.Stroke({color: 'rgba(217, 85, 82,1)', width: 4})
 });
 
 mviewer.featureStyles.circle1 = new ol.style.Style({
@@ -49,6 +49,46 @@ mviewer.featureStyles.circle1 = new ol.style.Style({
         })
     })
 });
+
+var _selectFillColor = 'rgba(82, 98, 217, 0.5)';
+var _selectStrokeColor = 'rgba(82, 98, 217, 1)';
+
+var _highlightSelect = {
+    'Point': new ol.style.Style({
+      image: new ol.style.Circle({
+        radius: 7,
+        fill: new ol.style.Fill({
+          color: _selectFillColor
+        }),
+        stroke: new ol.style.Stroke({
+          color: _selectStrokeColor,
+          width: 2
+        })
+      })
+    }),
+    'LineString': new ol.style.Style({
+      stroke: new ol.style.Stroke({
+        color: _selectStrokeColor,
+        width: 4
+      })
+    }),
+    'Polygon': new ol.style.Style({
+      fill: new ol.style.Fill({
+        color: _selectFillColor
+      }),
+      stroke: new ol.style.Stroke({
+        color: _selectStrokeColor,
+        width: 4
+      })
+    })
+};
+_highlightSelect['MultiPoint'] = _highlightSelect['Point'];
+_highlightSelect['MultiLineString'] = _highlightSelect['LineString'];
+_highlightSelect['MultiPolygon'] = _highlightSelect['Polygon'];
+
+var getSelectStyle = function(feature) {
+    return _highlightSelect[feature.getGeometry().getType()];
+}
 
 var getText = function(feature, resolution) {
     var type = 'Normal';

--- a/js/info.js
+++ b/js/info.js
@@ -81,22 +81,6 @@ var info = (function () {
     var _sourceOverlay;
 
     /**
-     * Property: _sourceSelectOverlay
-     * @type {ol.source.Vector}
-     * Used to hightlight selected vector features
-     */
-
-    var _sourceSelectOverlay;
-
-    /**
-     * Property: _sourceSubSelectOverlay
-     * @type {ol.source.Vector}
-     * Used to hightlight sub selected vector feature
-     */
-
-    var _sourceSubSelectOverlay;
-
-    /**
      * Property: _queriedFeatures
      * Array of ol.Feature
      * Used to store features retrieved on click
@@ -434,7 +418,7 @@ var info = (function () {
                 if (showFallbackPin) {
                     mviewer.showLocation(_projection.getCode(), _clickCoordinates[0], _clickCoordinates[1]);
                 } else {
-                    mviewer.hideLocation();
+                    $("#mv_marker").hide();
                 }
             });
             $('#loading-indicator').hide();
@@ -772,8 +756,6 @@ var info = (function () {
             _panelsTemplate["bottom-panel"] = configuration.getConfiguration().application.templatebottominfopanel;
         }
         _sourceOverlay = mviewer.getSourceOverlay();
-        _sourceSelectOverlay = mviewer.getSourceSelectOverlay();
-        _sourceSubSelectOverlay = mviewer.getSourceSubSelectOverlay();
         $.each(_overLayers, function (i, layer) {
             if (layer.queryable) {
                 _addQueryableLayer(layer);

--- a/js/info.js
+++ b/js/info.js
@@ -664,6 +664,7 @@ var info = (function () {
         var tpl = olayer.template;
         var obj = {features: []};
         var activeAttributeValue = false;
+        var geojson = new ol.format.GeoJSON();
         // if attributeControl is used for this layer, get the active attribute value and
         // set this value as property like 'value= true'. This allows use this value in Mustache template
         if (olayer.attributefilter && olayer.layer.getSource().getParams()['CQL_FILTER']) {
@@ -679,7 +680,8 @@ var info = (function () {
               fields_kv = [];
               keys = Object.keys(this);
               for (i = 0 ; i < keys.length ; i++ ) {
-                if (keys[i] == "fields_kv" || keys[i] == "serialized") {
+                if (keys[i] == "fields_kv" || keys[i] == "serialized" 
+                    || keys[i] === "feature_ol_uid" || keys[i] === "mviewerid" || typeof this[keys[i]] === "object") {
                   continue;
                 }
                 field_kv = {
@@ -694,7 +696,7 @@ var info = (function () {
             // add a serialized version of the object so it can easily be passed through HTML GET request
             // you can deserialize it with `JSON.parse(data)` when data is the serialized data
             var serialized = function () {
-              return encodeURIComponent(JSON.stringify(feature.getProperties()));
+              return encodeURIComponent(geojson.writeFeature(feature));
             }
             feature.setProperties({'serialized': serialized})
             // attach ol_uid to identify feature in DOM (not all features have a feature id as property)

--- a/js/info.js
+++ b/js/info.js
@@ -698,7 +698,7 @@ var info = (function () {
             }
             feature.setProperties({'serialized': serialized})
             // attach ol_uid to identify feature in DOM (not all features have a feature id as property)
-            obj.features.push({...feature.getProperties(), feature_id: feature.ol_uid});
+            obj.features.push({...feature.getProperties(), feature_ol_uid: feature.ol_uid});
         });
         var rendered = Mustache.render(tpl, obj);
         return _customizeHTML(rendered, olfeatures.length);

--- a/js/info.js
+++ b/js/info.js
@@ -339,10 +339,16 @@ var info = (function () {
                         "name": name,
                         "layerid": layerid,
                         "theme_icon": theme_icon,
-                        "html": html_result.join("")
+                        "html": html_result.join(""),
+                        "pin": showFallbackPin
                     });
                 }
             });
+            var infoLayers = [];
+            for (var panel in views) {
+                infoLayers = infoLayers.concat(views[panel].layers);
+            }
+            mviewer.setInfoLayers(infoLayers);
 
             $.each(views, function (panel, view) {
                 if (views[panel].layers.length > 0){

--- a/js/info.js
+++ b/js/info.js
@@ -137,7 +137,7 @@ var info = (function () {
     var _queryMap = function (evt, options) { 
         _queriedFeatures = [];
         _firstlayerFeatures = [];
-        var showFallbackPin = false;
+        var showPin = false;
         var queryType = "map"; // default behaviour
         var views = {
             "right-panel":{ "panel": "right-panel", "layers": []},
@@ -168,7 +168,11 @@ var info = (function () {
                 if (l && l != 'featureoverlay' && l != 'selectoverlay' && l != 'subselectoverlay' && l != 'elasticsearch' ) {
                     var queryable = _overLayers[l].queryable;
                     if (queryable) {
-                        _queriedFeatures.push(feature);
+                        if (layer.get('infohighlight')) {
+                            _queriedFeatures.push(feature);
+                        } else {
+                            showPin = true;
+                        }
                         if (vectorLayers[l] && vectorLayers[l].features) {
                             vectorLayers[l].features.push(feature);
                         } else {
@@ -260,6 +264,7 @@ var info = (function () {
                 var theme = layerinfos.theme;
                 var layerid = layerinfos.layerid;
                 var theme_icon = layerinfos.icon;
+                var infohighlight = layerinfos.infohighlight;
                 var id = views[panel].layers.length + 1;
                 var manyfeatures = false;
                 var html_result = [];
@@ -274,7 +279,7 @@ var info = (function () {
                             && (layerResponse.search('<!--nodatadetect-->\n<!--nodatadetect-->')<0)) {
                             html = layerResponse;
                             // no geometry in html
-                            showFallbackPin = true;
+                            showPin = true;
                         }
                         break;
                     case "application/vnd.ogc.gml":
@@ -314,9 +319,13 @@ var info = (function () {
                         var getFeatureInfo = _parseWMSGetFeatureInfo(xml, layerid);
                         // no geometry could be found in gml
                         if (!getFeatureInfo.hasGeometry) {
-                            showFallbackPin = true;
+                            showPin = true;
                         }
-                        _queriedFeatures.push.apply(_queriedFeatures, getFeatureInfo.features);
+                        if (infohighlight) {
+                            _queriedFeatures.push.apply(_queriedFeatures, getFeatureInfo.features);
+                        } else {
+                            showPin = true;
+                        }
                         var features = getFeatureInfo.features;
                         if (features.length > 0) {
                             if (layerinfos.template) {
@@ -340,7 +349,7 @@ var info = (function () {
                         "layerid": layerid,
                         "theme_icon": theme_icon,
                         "html": html_result.join(""),
-                        "pin": showFallbackPin
+                        "pin": showPin
                     });
                 }
             });
@@ -421,7 +430,7 @@ var info = (function () {
                 mviewer.highlightFeatures(_queriedFeatures);
                 mviewer.highlightSubFeature(_firstlayerFeatures[0]);
                 // show pin as fallback if no geometry for wms layer
-                if (showFallbackPin) {
+                if (showPin) {
                     mviewer.showLocation(_projection.getCode(), _clickCoordinates[0], _clickCoordinates[1]);
                 } else {
                     $("#mv_marker").hide();

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -642,6 +642,7 @@ mviewer = (function () {
         if (oLayer.scale && oLayer.scale.min) { l.setMinResolution(_convertScale2Resolution(oLayer.scale.min)); }
         l.set('name', oLayer.name);
         l.set('mviewerid', oLayer.id);
+        l.set('infohighlight', oLayer.infohighlight);
 
         if (oLayer.searchable) {
             search.processSearchableLayer(oLayer);

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -1992,7 +1992,9 @@ mviewer = (function () {
          */
         highlightFeatures: function (features) {
             _sourceSelectOverlay.clear();
-            if (features.length > 0) {
+            // note: features from vectortiles provoke error on addFeatures()
+            // workaround: exclude them by checking if feature has a getGeometryName() function
+            if (features.length > 0 && typeof features[0].getGeometryName === "function") {
                 _sourceSelectOverlay.addFeatures(features);
             }
         },

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -499,9 +499,9 @@ mviewer = (function () {
         _sourceSelectOverlay = new ol.source.Vector();
         _selectOverlayFeatureLayer = new ol.layer.Vector({
             source: _sourceSelectOverlay,
-            style: getSelectStyle.bind(this, '82, 98, 217', 4)
+            style: getSelectStyle.bind(this, '82, 98, 217', 4),
+            mviewerid: 'selectoverlay'
         });
-        _selectOverlayFeatureLayer.set('mviewerid', 'selectoverlay');
         _map.addLayer(_selectOverlayFeatureLayer);
     };
 
@@ -515,9 +515,9 @@ mviewer = (function () {
         _sourceSubSelectOverlay = new ol.source.Vector();
         _subSelectOverlayFeatureLayer = new ol.layer.Vector({
             source: _sourceSubSelectOverlay,
-            style: getSelectStyle.bind(this, '252, 186, 3', 2)
+            style: getSelectStyle.bind(this, '252, 186, 3', 2),
+            mviewerid: 'subselectoverlay'
         });
-        _subSelectOverlayFeatureLayer.set('mviewerid', 'subselectoverlay');
         _map.addLayer(_subSelectOverlayFeatureLayer);
     };
 
@@ -2064,17 +2064,8 @@ mviewer = (function () {
          */
 
         hideLocation: function ( ) {
-            $("#mv_marker").hide();
-        },
-
-        /**
-         * Public Method: hideSelectOverlay
-         *
-         */
-        hideSelectOverlay: function ( ) {
             _sourceSelectOverlay.clear();
             _sourceSubSelectOverlay.clear();
-            // for case that fallback pin is present
             $("#mv_marker").hide();
         },
 
@@ -2737,7 +2728,7 @@ mviewer = (function () {
                 if (feature.get("mviewerid") === layerid) {
                     _sourceSelectOverlay.removeFeature(feature);
                     _sourceSubSelectOverlay.getFeatures().forEach(subFeature => {
-                        if (feature.ol_uid == subFeature.ol_uid) {
+                        if (feature.ol_uid === subFeature.ol_uid) {
                             _sourceSubSelectOverlay.removeFeature(subFeature)
                         }
                     })
@@ -2750,9 +2741,6 @@ mviewer = (function () {
                 if (panel.hasClass("active")) {
                     panel.toggleClass("active");
                 }
-                // only necessary for fallback pin (GetFeatureInfo without geometry).
-                // could be improved by checking if one of the displayed layers is concerned
-                // instead of calling it on last one
                 $("#mv_marker").hide();
             } else {
                 if ( tab.hasClass("active") ) {
@@ -2851,10 +2839,7 @@ mviewer = (function () {
         getProjection: function () { return _projection; },
 
         getSourceOverlay: function () { return _sourceOverlay; },
-
-        getSourceSelectOverlay: function () { return _sourceSelectOverlay; },
-
-        getSourceSubSelectOverlay: function () { return _sourceSubSelectOverlay; },
+        
 
         setTopLayer: function (layer) { _topLayer = layer; },
 

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -258,6 +258,13 @@ mviewer = (function () {
 
     var _subSelectOverlayFeatureLayer = false;
 
+    /**
+     * Property: _infoLayers
+     * Array of custom panel objects
+     * Used to keep track of layers displayed in info panels
+     */
+    var _infoLayers = [];
+
     var _setVariables = function () {
         _proxy = configuration.getProxy();
     };
@@ -2734,6 +2741,18 @@ mviewer = (function () {
                     })
                 }
             })
+            // remove layer from infoLayers
+            _infoLayers = _infoLayers.filter(infoLayer => {
+                return infoLayer.layerid !== layerid;
+            })
+            // get layers with pin
+            var pinLayers = _infoLayers.filter(infoLayer => {
+                return infoLayer.pin;
+            })
+            // remove pin on last layer with pin
+            if (pinLayers.length === 0) {
+                $("#mv_marker").hide();
+            }
 
             if ( tabs.length === 1 ) {
                 tab.remove();
@@ -2839,9 +2858,10 @@ mviewer = (function () {
         getProjection: function () { return _projection; },
 
         getSourceOverlay: function () { return _sourceOverlay; },
-        
 
         setTopLayer: function (layer) { _topLayer = layer; },
+
+        setInfoLayers: function (infoLayers) { _infoLayers = infoLayers; },
 
         createBaseLayer: _createBaseLayer,
 

--- a/js/templates.js
+++ b/js/templates.js
@@ -253,7 +253,7 @@ mviewer.templates.featureInfo.accordion = [
                 '<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true" style="list-style: none;">',
                 '{{#layers}}',
                   '<div class="panel">',
-                    '<div class="panel-heading mv-theme" role="tab" id="heading-{{panel}}-{{id}}">',
+                    '<div class="panel-heading mv-theme" role="tab" id="heading-{{panel}}-{{id}}" data-layerid="{{layerid}}">',
                       '<h4 class="panel-title">',
                         '<a role="button" data-toggle="collapse" data-parent="#accordion" href="#accordion-{{panel}}-{{id}}" aria-expanded="{{#firstlayer}}true{{/firstlayer}}{{^firstlayer}}false{{/firstlayer}}" aria-controls="accordion-{{panel}}-{{id}}">',
                         '{{name}}',

--- a/templates/cadastre.parcel.mst
+++ b/templates/cadastre.parcel.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li id="{{feature_id}}" class="item" style="width:238px;">
+	<li id="{{feature_ol_uid}}" class="item" style="width:238px;">
 		<h5 class="title-feature">Parcelle {{nationalcadastralreference}}</h5>
 		<p class="text-feature">		
 			<span style="font-family:'roboto_bold'"> Surface :</span> {{areavalue}} m2<br/>

--- a/templates/cadastre.parcel.mst
+++ b/templates/cadastre.parcel.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li class="item" style="width:238px;">
+	<li id="{{feature_id}}" class="item" style="width:238px;">
 		<h5 class="title-feature">Parcelle {{nationalcadastralreference}}</h5>
 		<p class="text-feature">		
 			<span style="font-family:'roboto_bold'"> Surface :</span> {{areavalue}} m2<br/>

--- a/templates/demo.sirene.mst
+++ b/templates/demo.sirene.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li class="item" style="width:238px;">
+	<li id="{{feature_id}}" class="item" style="width:238px;">
 		{{#enseigne}}
 			<h5 class="title-feature">{{enseigne}}</h5>
 		{{/enseigne}}

--- a/templates/demo.sirene.mst
+++ b/templates/demo.sirene.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li id="{{feature_id}}" class="item" style="width:238px;">
+	<li id="{{feature_ol_uid}}" class="item" style="width:238px;">
 		{{#enseigne}}
 			<h5 class="title-feature">{{enseigne}}</h5>
 		{{/enseigne}}

--- a/templates/global.aeroport.mst
+++ b/templates/global.aeroport.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li id="{{feature_id}}" class="item" style="width:238px;">
+	<li id="{{feature_ol_uid}}" class="item" style="width:238px;">
 		<h3 class="title-feature">{{TYPE}} de {{NOM}}</h3>
 		<p class="text-feature">		
 			<span style="font-family:'roboto_bold'"> Commune :</span> {{COMMUNE}}<br/>

--- a/templates/global.aeroport.mst
+++ b/templates/global.aeroport.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li class="item" style="width:238px;">
+	<li id="{{feature_id}}" class="item" style="width:238px;">
 		<h3 class="title-feature">{{TYPE}} de {{NOM}}</h3>
 		<p class="text-feature">		
 			<span style="font-family:'roboto_bold'"> Commune :</span> {{COMMUNE}}<br/>

--- a/templates/global.arret_ferroviaire.mst
+++ b/templates/global.arret_ferroviaire.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li class="item" style="width:238px;">
+	<li id="{{feature_id}}" class="item" style="width:238px;">
 		<h3 class="title-feature">{{nom}}</h3>
 
 		<img src="{{photo}}" class="img-responsive" style="margin-top:5%;" />

--- a/templates/global.arret_ferroviaire.mst
+++ b/templates/global.arret_ferroviaire.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li id="{{feature_id}}" class="item" style="width:238px;">
+	<li id="{{feature_ol_uid}}" class="item" style="width:238px;">
 		<h3 class="title-feature">{{nom}}</h3>
 
 		<img src="{{photo}}" class="img-responsive" style="margin-top:5%;" />

--- a/templates/global.gare_maritime.mst
+++ b/templates/global.gare_maritime.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li class="item" style="width:238px;">
+	<li id="{{feature_id}}" class="item" style="width:238px;">
 		<h3 class="title-feature">Gare maritime de {{NOM}}</h3>
 	</li>
 {{/features}}

--- a/templates/global.gare_maritime.mst
+++ b/templates/global.gare_maritime.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li id="{{feature_id}}" class="item" style="width:238px;">
+	<li id="{{feature_ol_uid}}" class="item" style="width:238px;">
 		<h3 class="title-feature">Gare maritime de {{NOM}}</h3>
 	</li>
 {{/features}}

--- a/templates/global.lycee.mst
+++ b/templates/global.lycee.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li id="{{feature_id}}" class="item" style="width:238px;">
+	<li id="{{feature_ol_uid}}" class="item" style="width:238px;">
 		<h3 class="title-feature">{{nom}}</h3>
 		<p class="text-feature">
 			<h4 class="sub-title">Localisation</h4>		

--- a/templates/global.lycee.mst
+++ b/templates/global.lycee.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li class="item" style="width:238px;">
+	<li id="{{feature_id}}" class="item" style="width:238px;">
 		<h3 class="title-feature">{{nom}}</h3>
 		<p class="text-feature">
 			<h4 class="sub-title">Localisation</h4>		

--- a/templates/global.port.mst
+++ b/templates/global.port.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li id="{{feature_id}}" class="item" style="width:238px;">
+	<li id="{{feature_ol_uid}}" class="item" style="width:238px;">
 		<h3 class="title-feature">Port de {{libelle_po}}</h3>
 	</li>
 {{/features}}

--- a/templates/global.port.mst
+++ b/templates/global.port.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li class="item" style="width:238px;">
+	<li id="{{feature_id}}" class="item" style="width:238px;">
 		<h3 class="title-feature">Port de {{libelle_po}}</h3>
 	</li>
 {{/features}}

--- a/templates/global.reserve_naturelle_reg.mst
+++ b/templates/global.reserve_naturelle_reg.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li class="item" style="width:238px;">
+	<li id="{{feature_id}}" class="item" style="width:238px;">
 		<h3 class="title-feature">{{nom}}</h3>
 		{{#image}}
 			<img src="{{image}}" class="img-responsive" style="margin-top:5%;" />

--- a/templates/global.reserve_naturelle_reg.mst
+++ b/templates/global.reserve_naturelle_reg.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li id="{{feature_id}}" class="item" style="width:238px;">
+	<li id="{{feature_ol_uid}}" class="item" style="width:238px;">
 		<h3 class="title-feature">{{nom}}</h3>
 		{{#image}}
 			<img src="{{image}}" class="img-responsive" style="margin-top:5%;" />

--- a/templates/inventaire.mst
+++ b/templates/inventaire.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li class="inventaire item" style="width:100%;">
+	<li id="{{feature_id}}" class="inventaire item" style="width:100%;">
 		<h3 class="title-feature">{{title}}</h3>
         <p class="source" ><i>Source: <strong>{{source}}</strong></i></p>
 		<p class="text-feature">

--- a/templates/inventaire.mst
+++ b/templates/inventaire.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li id="{{feature_id}}" class="inventaire item" style="width:100%;">
+	<li id="{{feature_ol_uid}}" class="inventaire item" style="width:100%;">
 		<h3 class="title-feature">{{title}}</h3>
         <p class="source" ><i>Source: <strong>{{source}}</strong></i></p>
 		<p class="text-feature">

--- a/templates/transport.ligne_ferroviaire.mst
+++ b/templates/transport.ligne_ferroviaire.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li class="item" style="width:238px;">
+	<li id="{{feature_id}}" class="item" style="width:238px;">
 		<h3 class="title-feature">{{nom_ligne}}</h3>
 		<p class="text-feature">
 			<span style="font-family:'roboto_bold'"> Axe :</span> {{axe}}<br/>

--- a/templates/transport.ligne_ferroviaire.mst
+++ b/templates/transport.ligne_ferroviaire.mst
@@ -1,5 +1,5 @@
 {{#features}}
-	<li id="{{feature_id}}" class="item" style="width:238px;">
+	<li id="{{feature_ol_uid}}" class="item" style="width:238px;">
 		<h3 class="title-feature">{{nom_ligne}}</h3>
 		<p class="text-feature">
 			<span style="font-family:'roboto_bold'"> Axe :</span> {{axe}}<br/>


### PR DESCRIPTION
This PR replaces the pin/marker for the info tool by highlighting the selected feature (if a geometry can be found) and is meant to resolve #315 . The pin is kept as a fallback for WMS GetFeatureInfo responses in HTML and GML without geometry.

The highlighting is done on a new source/layer to stay independent of hovering (but finally might be moved to the same).

Another source/layer pair was added to allow a sub selection of the feature currently visible in the info panel. To allow synchronizing actions of the carousel and the map a `feature_id` needed to be injected to the DOM which affected templating (see the doc). The internal `ol_uid` was used for this matter, as not all layers include a feature id as a property.

The PR was tested against:
* WMS layers (Geoserver, Mapserver):
  * returning GML with geometry
  * returning GML without geometry
  * returning HTML
* Vectorlayers:
  * Customlayers (geojson)
  * CSV layer

_Search highlighting_

The PR does not address highlighting of search results in particular, which is already present for elastic search and in my opinion makes less sense than a pin for a point result (often returned by geocoding services as ban). However if the `searchparameter` `querymaponclick` is set to `true` the highlighting naturally also takes affect on fuse searches, as the info tool is called.