### PR TITLE
Allow many CSS files import

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -140,8 +140,12 @@ class Component {
           if (that.config.options && that.config.options.title) {
             component.title = that.config.options.title;
           }
-          if (that.config.css) {
-            _html.push('<link href="'+ that.path + that.config.css +'" rel="stylesheet" >');
+          // use url as string or urls as array from config
+          if (that.config.css && typeof that.config.css === 'String') {
+            _html.push('<link href="'+ that.path + that.config.css +'" rel="stylesheet">');
+          } else if(that.config.css) {
+            let cssSheets = that.config.css.map(s => `<link href="${that.path + s}" rel="stylesheet">`);
+            _html = _html.concat(cssSheets);
           }
           _html.push(html);
           component.innerHTML = _html.join("");


### PR DESCRIPTION
Fix #367 
This PR is compliant with old version ( => load only one CSS from simple path as String).