### PR TITLE
Method to display top layer on map

### DIFF
--- a/index.html
+++ b/index.html
@@ -526,7 +526,7 @@
                 success: function (xml) {
                     $( document ).on( "layersLoaded", function (e) {
                         mviewer.overLayersReady();
-                        mviewer.orderFirstLayer();
+                        mviewer.orderTopLayer();
                     });
                     //load conf
                     $( document ).on( "configurationCompleted", function (e, eData) {

--- a/index.html
+++ b/index.html
@@ -526,6 +526,7 @@
                 success: function (xml) {
                     $( document ).on( "layersLoaded", function (e) {
                         mviewer.overLayersReady();
+                        mviewer.orderFirstLayer();
                     });
                     //load conf
                     $( document ).on( "configurationCompleted", function (e, eData) {

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -1839,6 +1839,23 @@ mviewer = (function () {
 
         },
 
+        orderFirstLayer: function() {
+            if(_topLayer) {
+                var layersId = _map.getLayers().getArray().filter(e => e.getProperties().mviewerid === _topLayer);
+                if(!layersId.length) return; // no top layer to display over
+
+                // count base layers
+                var countLayers = configuration.getConfiguration().baselayers.baselayer.length;
+                // count themes layers
+                var themes = configuration.getConfiguration().themes.theme;
+                themes.forEach(e => {
+                    countLayers += e.layer.length
+                });
+                // set first layer over others theme or background layers and before system layers
+                mviewer.reorderLayer(layersId[0], countLayers-1);
+            }
+        },
+
         orderLayer: function (actionMove) {
             if (actionMove.layerRef) {
                 var layers = _map.getLayers().getArray();

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -1839,7 +1839,7 @@ mviewer = (function () {
 
         },
 
-        orderFirstLayer: function() {
+        orderTopLayer: function() {
             if(_topLayer) {
                 var layersId = _map.getLayers().getArray().filter(e => e.getProperties().mviewerid === _topLayer);
                 if(!layersId.length) return; // no top layer to display over


### PR DESCRIPTION
### Contributeurs
Merci au SESAN et à l'ARS Ile-de-France qui ont rendu possible cette contribution.

### Description

En lien avec #354, cette méthode permet de remettre la top layer comme première couche de la carte.

@spelhate je ne vois pas dans le code comment la top layer était mise en top layer sur la map openLayers. C'est bien le cas dans la légende mais je n'ai pas vu pour la carte.

Cette PR est peut-être donc inutile si le problème est ailleurs, mais dans l'exemple fourni ici avec @AnthonyNch, il n'y a pas de spécificité :
https://santegraphie.fr/mviewer3/app/cpts_v2.xml

Je pense qu'une revue est donc nécessaire pour être certain que cette PR est une bonne réponse à l'issue #354.