### PR TITLE
Github template issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/autre-demande.md
+++ b/.github/ISSUE_TEMPLATE/autre-demande.md
@@ -1,0 +1,14 @@
+---
+name: Autre demande
+about: Ce n'est ni un bug ni une évolution
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Description  / Describe**
+
+Vous souhaitez partager quelque chose, demander des informations ou avoir de l'aide sur la configuration ou l'utilisation du Mviewer.
+
+Décrivez votre message ici, nous vous répondrons dès que possible 😉.

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,42 @@
+---
+name: Bug
+about: Créer un rapport de bug
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Description du bug / Describe the bug**
+
+Une description courte du problème
+
+
+**Reproduire le bug / To Reproduce**
+
+Etapes à suivre pour reproduire votre problème du type : 
+
+1. Aller sur la plage https://mon.mviewer.xml
+2. Cliqué sur Rechercher
+3. Saisir quelque chose
+4. Voir que rien ne se passe (ou l'erreur si identifiable)
+
+**Comportement attendu / Exptected behavior**
+
+Une description courte de ce que vous auriez voulu voir, ce qui ce serait passé sans le problème.
+
+**Screenshots**
+
+Si possible, une capture d'écran pour nous aider à voir le problème décrit.
+
+**Environnement / Desktop**
+
+Merci de remplir ces informations si connues :
+ - OS: [e.g. iOS]
+ - Navigateur / browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Informations complémentaires / Additional context**
+
+
+Préciser par exemple si le problème a été vu suite à l'installation d'une nouvelle version ou suite à des modifications que vous auriez faites dans votre Mviewer.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Créer un rapport de bug
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Description du bug / Describe the bug**
+
+Une description courte du problème
+
+
+**Reproduire le bug / To Reproduce**
+
+Etapes à suivre pour reproduire votre problème du type : 
+
+1. Aller sur la plage https://mon.mviewer.xml
+2. Cliqué sur Rechercher
+3. Saisir quelque chose
+4. Voir que rien ne se passe (ou l'erreur si identifiable)
+
+**Comportement attendu / Exptected behavior**
+
+Une description courte de ce que vous auriez voulu voir, ce qui ce serait passé sans le problème.
+
+**Screenshots**
+
+Si possible, une capture d'écran pour nous aider à voir le problème décrit.
+
+**Environnement / Desktop**
+
+Merci de remplir ces informations si connues :
+ - OS: [e.g. iOS]
+ - Navigateur / browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Informations complémentaires / Additional context**
+
+
+Préciser par exemple si le problème a été vu suite à l'installation d'une nouvelle version ou suite à des modifications que vous auriez faites dans votre Mviewer.

--- a/.github/ISSUE_TEMPLATE/evolution.md
+++ b/.github/ISSUE_TEMPLATE/evolution.md
@@ -1,0 +1,21 @@
+---
+name: Evolution
+about: Améliorer ou proposer une idée
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Description détaillée / Describe**
+
+Une courte et description de ce que vous voulez.
+Cela peut toucher une fonctionnalité qui existe (ex: améliorer un outil de mesure) ou l'ajout d'une nouvelle fonctionnalité qui n'existe pas dans le Mviewer.
+
+**Description détaillée / Detailed description**
+
+Si vous avez une idée de comment mettre en place cette évolution, vous pouvez tout détailler ici.
+
+**Informations complémentaires / Additional context**
+
+Toutes informations complémentaire que vous jugez utiles.


### PR DESCRIPTION
Lorsqu'on crée une issue, on part d'une page blanche et cela peut être déstabilisant si on en a pas l'habitude.

A la lecture c'est en plus parfois compliquer de comprendre le message de l'issue.

GitHub propose des templates pour remédier à ce soucis.

Je propose donc 3 template d'issue qui peuvent nous servir :

* Bug
* Evolution
* Autre demande (question, support technique, sujet de stage, autre...)