### PR TITLE
Add favicon parameter in application. Linked to #449

### DIFF
--- a/docs/doc_tech/config_app.rst
+++ b/docs/doc_tech/config_app.rst
@@ -36,6 +36,7 @@ Personnalisation de l'application
 		mapfishurl=""
 		lang=""
 		langfile=""
+		favicon=""
         />
 
 **Paramètres**
@@ -63,6 +64,7 @@ Personnalisation de l'application
 * ``hideprotectedlayers``: Indique si les couches protégées doivent être masquées dans l'arbre des thématiques lorsque l'utilisateur n'y a pas accès. Valeur : true/false (true par défaut).
 * ``lang``: Langue à utiliser pour l'interface. Passer "?lang=en" dans l'url pour forcer la langue et ignorer la config. Par défaut, lang n'est pas activé. Le fichier mviewer.i18n.json contient les expressions à traduire dans différentes langues. Pour traduire le texte d'un élément html, il faut que cet élément dispose d'un attribut i18n=texte.a.traduire. En javascript la traduction s'appuie sur la méthode mviewer.tr("texte.a.traduire").
 * ``langfile``: URL du fichier de traduction supplémentaire à utiliser en complément de mviewer.i18n.json.
+* ``favicon``: URL du fichier image à utiliser comme favicon de l'application.
 
 
 **Exemple**
@@ -75,4 +77,5 @@ Personnalisation de l'application
 		help=""
 		exportpng="false"
 		measuretools="true"
+		favicon="https://www.bretagne.bzh/app/themes/bretagne/dist/img/icons/favicon.ico"
 		style="css/themes/blue.css"/>

--- a/index.html
+++ b/index.html
@@ -544,6 +544,11 @@
                             title = _conf.application.title;
                             $("#loader-subtitle").text(title);
                         }
+                        if (_conf.application.favicon) {
+                            let ico = _conf.application.favicon;
+                            let favicon = document.querySelector('link[rel="icon"]');
+                            favicon.attributes.href.value = ico;
+                        }
                         configuration.load(_conf);
                         setTimeout(function () {
                             $("#loading-page").hide();


### PR DESCRIPTION
Add new favicon parameter in application config. See #449.
If parameter is not set, default mviewer favicon is used. Example : `favicon="https://www.bretagne.bzh/app/themes/bretagne/dist/img/icons/favicon"`
