### PR TITLE
Affichage d'une couche sur la carte mais pas dans la légende.

### DIFF
--- a/js/configuration.js
+++ b/js/configuration.js
@@ -632,6 +632,7 @@ var configuration = (function () {
                     oLayer.vectorlegend =  (layer.vectorlegend === "true") ? true : false;
                     oLayer.nohighlight =  (layer.nohighlight === "true") ? true : false;
                     oLayer.infohighlight =  (layer.infohighlight === "false") ? false : true;
+                    oLayer.showintoc =  (layer.showintoc && layer.showintoc === "false") ? false : true;
                     oLayer.legendurl=(layer.legendurl)? layer.legendurl : mviewer.getLegendUrl(oLayer);
                     if (oLayer.legendurl === "false") {oLayer.legendurl = "";}
                     oLayer.useproxy = (layer.useproxy === "true") ? true : false;

--- a/js/info.js
+++ b/js/info.js
@@ -799,7 +799,7 @@ var info = (function () {
         }
         _sourceOverlay = mviewer.getSourceOverlay();
         $.each(_overLayers, function (i, layer) {
-            if (layer.queryable) {
+            if (layer.queryable && layer.showintoc) {
                 _addQueryableLayer(layer);
             }
         });

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -333,7 +333,7 @@ mviewer = (function () {
                 center: _center,
                 enableRotation: _rotation,
                 zoom: _zoom,
-                extent: mapoptions.maxextent 
+                extent: mapoptions.maxextent
                     ? mapoptions.maxextent.split(",").map(function(item) {return parseFloat(item);})
                     : undefined
             })
@@ -864,7 +864,9 @@ mviewer = (function () {
                 $.each(_themes[theme.id].groups, function (id, group) {
                     var grp = {title: group.name, layers: [] };
                     $.each(group.layers, function (id, layer) {
-                        grp.layers.unshift(layer);
+                        if (layer.showintoc) {
+                            grp.layers.unshift(layer);
+                        }
                     });
                     groups.push(grp);
                 });
@@ -873,7 +875,10 @@ mviewer = (function () {
             //NO GROUPS
             } else {
                  $.each(_themes[theme.id].layers, function (id, layer) {
-                    reverse_layers.push(layer);
+                    if (layer.showintoc) {
+                        reverse_layers.push(layer);
+                    }
+
                 });
                 view.layers = reverse_layers.reverse();
                 view.cls = classes.join(" ");
@@ -2180,7 +2185,7 @@ mviewer = (function () {
         },
 
         addLayer: function (layer) {
-            if (!layer) {
+            if (!layer || !layer.showintoc) {
                 return;
             }
             if (layer.exclusive) {


### PR DESCRIPTION
Création d'un nouveau paramètre de couche : **showintoc**

Par défaut ce paramètre a la valeur **true**. Pour désactiver l'affichage d'une couche dans la légende et l'arborescence des thématiques, il faut attribuer la valeur **false** à ce paramètre.

Cette fonctionnalité est utile pour afficher une couche de type masque ou bien encore une couche en surimpression des couches de fond. Lien avec #209
