### PR TITLE
Add capability to store small custom config in permalink

### DIFF
--- a/customcontrols/inventaire.js
+++ b/customcontrols/inventaire.js
@@ -7,6 +7,10 @@ mviewer.customControls.inventaire = (function() {
     var _zoomlevel = false;
 
     var _defaultValue = "maison,18e siècle,ardoise";
+    // Verify if a filter is defined in permalink and get filter if exists.
+    if (API[`c_${_idlayer}`]) {
+        _defaultValue = API[`c_${_idlayer}`];
+    }
 
     var _lastValues = false;
 
@@ -15,6 +19,8 @@ mviewer.customControls.inventaire = (function() {
     var _updateLayer = function() {
         var values = $("#inventaire_search_queries").tagsinput('items') || [];
         mviewer.customLayers.inventaire.setFilter(values);
+        //Save filter in API to reuse it in permalink.
+        API[`c_${_idlayer}`] = values.join(",");
         mviewer.customLayers.inventaire.layer.getSource().getSource().refresh();
         mviewer.customLayers.inventaire.layer.getSource().getSource().changed();
         _lastValues = values.join(",");

--- a/docs/doc_tech/config_intro.rst
+++ b/docs/doc_tech/config_intro.rst
@@ -61,6 +61,7 @@ Paramètres d'URL utilisés pour les permaliens
 * ``y`` : Coordonnées y du centre de la carte dans le système de projection utilisé par l'application.
 * ``z`` : Zoom de la carte (1 à 20).
 * ``lb`` : Identifiant de la couche de fond affichée.
+* ``c_[monparam]`` : où mon param est l'identifiant du composant personnalisé ou de la couche personalisée. La valeur du paramètre peut ensuite être utilisée par le composant ou la couche concernée. exemple c_mycustomlayer=red,blue,green
 
 Sections de configurations
 ----------------------------

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -1990,6 +1990,14 @@ mviewer = (function () {
             }
             linkParams.mode = $('input[name=mv-display-mode]:checked').val();
 
+            //Get extra params from API. Params has to begin with c_
+            let reg = /^c_(.*)/;
+            for (const [key, value] of Object.entries(API)) {
+                if (key.match(reg)) {
+                    linkParams[key] = API[key]
+                }
+            }
+
             var url = window.location.href.split('#')[0].split('?')[0] + '?' + $.param(linkParams);
             $("#permalinklink").attr('href',url).attr("target", "_blank");
             $("#permaqr").attr("src","http://chart.apis.google.com/chart?cht=qr&chs=140x140&chl=" + encodeURIComponent(url));


### PR DESCRIPTION
In mviewer, permalink is constructed from public API object.
With this small adaptation, all API properties beginning with c_ like c_mycustomlayer are used in permalink.
This is the core implementation.
Then in each customlayer or component, user will have to add two methods to get and set this custom param.
Example to get value

if (API[`c_${_idlayer}`]) {
        _defaultValue = API[`c_${_idlayer}`];
    }
Example to set value

API[c_${_idlayer}] = 'test1,test2';

See #492