### PR TITLE
Add new layer parameter jsonfields. 

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -479,6 +479,18 @@ h1 {
                     </div>
                 </div>
             </div>
+            <div class="col-lg-4 col-md-6 col-sm-12">
+                <div class="well">
+                    <p class="text-right"><span class="label label-success">Simple</span><span class="label label-info">release</span><span class="label label-info">v3.5</span></p>
+                    <h3>Démo mviewer champ json</h3>
+                    <hr><strong>Cette démo utilise le paramètre de champ jsonfields qui permet par la suite d'itérer sur des listes avec les templates sans code javascript.</strong></br>
+                    <p>Dans le cas présenté ici, le champ communes contient la liste des communes pour chaque EPCI</p>
+                    <hr>
+                    <div class="text-center">
+                        <div class="btn-group btn-group-xs"><a href="../demo/jsonfields.xml" target="_blank" class="btn btn-danger"><span class="glyphicon glyphicon-download"></span> Sources</a><a href="../?config=demo/jsonfields.xml" target="_blank" class="btn btn-primary"><span class="glyphicon glyphicon-globe"></span> Live!</a></div>
+                    </div>
+                </div>
+            </div>
 
 
 

--- a/demo/jsonfields.mst
+++ b/demo/jsonfields.mst
@@ -1,0 +1,28 @@
+{{#features}} 
+<li class="item" id="{{feature_ol_uid}}"> 
+<h3 class="title-feature">{{nom}}</h3> 
+
+<div class="feature-text"><span>code_siren:</span> {{code_siren}}</div><br/>
+
+<!-- USE JSONFIELD (communes) wich returns json array to loop -->
+
+<h3> Liste des communes :</h3>
+<table style="width:100%;">
+    <thead>
+        <tr>
+            <th>NOM</th>
+            <th>CODE</th>
+
+        </tr>
+    </thead>
+    <tbody>
+        {{#communes}}
+            <tr>
+                <td>{{nom}}</td>
+                <td>{{code_insee}}</td>
+            </tr>
+          {{/communes}}
+    </tbody>
+</table> 
+</li> 
+{{/features}}

--- a/demo/jsonfields.xml
+++ b/demo/jsonfields.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+<application title="Jsonfield" logo="" help="" style="css/themes/default.css" exportpng="false" showhelp="false" coordinates="false" measuretools="false" togglealllayersfromtheme="false">
+</application>
+<mapoptions maxzoom="20" projection="EPSG:3857" center="-307903.74898791354,6141345.088741366" zoom="7"/>
+<searchparameters bbox="false" localities="false" features="false" static="false"/>
+<baselayers style="default"> 
+    <baselayer visible="true" id="positron" thumbgallery="img/basemap/positron.png" title="CartoDb" label="Positron" type="OSM" url="https://{a-c}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png" attribution="Map tiles by  &lt;a href=&quot;https://cartodb.com/attributions&quot;&gt;CartoDb&lt;/a&gt;, under  &lt;a href=&quot;https://creativecommons.org/licenses/by/3.0/&quot;&gt;CC BY 3.0 &lt;/a&gt;"/> 
+    <baselayer visible="false" id="esriworldimagery" thumbgallery="img/basemap/esriworldwide.jpg" title="Esri" label="Esri world imagery" type="OSM" url="http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}" attribution="Esri world imagery"/> 
+</baselayers>
+<themes mini="false"> 
+    <theme id="theme-20210526160030" name="TPL" collapsed="true" icon="fas fa-caret-right"> 
+        <layer id="demo_epci_communes2" name="layer jsonfield" type="wms"
+        url="https://ows.region-bretagne.fr/geoserver/rb/ows?"
+        jsonfields="communes"
+        visible="true" infoformat="application/vnd.ogc.gml" queryable="true" infopanel="right-panel">
+        <template url="demo/jsonfields.mst"></template>
+        </layer>       
+    </theme> 
+</themes>
+</config>

--- a/docs/doc_tech/config_layers.rst
+++ b/docs/doc_tech/config_layers.rst
@@ -26,6 +26,7 @@ Configurer - Les couches
                 queryable=""
                 fields=""
                 aliases=""
+                fieldsjson=""
                 type=""
                 filter=""
                 searchable=""
@@ -117,6 +118,7 @@ Paramètres pour gérer l'interrogation et la mise en forme de la fiche d'interr
 * ``featurecount`` :guilabel:`studio` : Nombre d'éléments retournés lors de l'interrogation
 * ``fields`` :guilabel:`studio` :  Si les informations retournées par l'interrogation est au format GML, fields représente les attributs à parser pour générer la vignette
 * ``aliases`` :guilabel:`studio` : Si les informations retournées par l'interrogation est au format GML, aliases représente le renommage des champs parsés.
+* ``fieldsjson`` : Liste des champs de type json. Avec ce paramètre, mviewer parse le contenu des champs spécifiés en JSON, ce qui permet ensuite d'exploiter ces valeurs dans des boucles de templates mustache  pour afficher une liste, un tableau...
 
 Paramètres pour gérer la recherche
 ======================================

--- a/docs/doc_tech/config_tpl.rst
+++ b/docs/doc_tech/config_tpl.rst
@@ -72,7 +72,7 @@ Les éléments en rouge sont obligatoires.
 
 Explications : ``{{#features}}{{/features}}`` est une boucle effectuée sur chaque entité présente dans la couche sélectionnée.
 ``<li id="{{feature_ol_uid}}" class="item"></li>`` est une entrée de liste html utilisée par le mviewer. S'il y a plusieurs entrées de liste car plusieurs entités sélectionnées, le mviewer présentera les réponses sous la forme d'un carousel.
-Pour synchroniser le carousel et la sous-sélection sur la carte lors d'un clic, l'injection de la ``feature_ol_uid`` est requise dans l' ``id`` de la balise. 
+Pour synchroniser le carousel et la sous-sélection sur la carte lors d'un clic, l'injection de la ``feature_ol_uid`` est requise dans l' ``id`` de la balise.
 Puisque une ``feature id`` n'est pas obligatoire comme attribut pour une feature l' ``ol_uid`` interne d'OpenLayers est utilisée à ce propos.
 
 Ce qu'il faut savoir de Mustache
@@ -101,6 +101,58 @@ Résultat de l'exemple ci-dessus
               :width: 400
               :alt: Exemple de template
               :align: center
+
+
+Itérer sur un champ de type json
+--------------------------------
+
+Prérequis : disposer d'un champ - exemple ``monchampjson`` -dont le contenu est une liste de valeurs ou d'objets sous la forme ``["item1","item2"]`` ou de la forme ``[{"nom": "item1", "code": 1}, {"nom": "item2", "code": 2}]``
+configurer le layer dans le config.xml avec le paramètre ``jsonfields="monchampjson"``
+
+Exemple 1 pour *monchampjson* = ``["item1","item2"]``
+
+.. code-block:: xml
+       :linenos:
+
+        {{#monchampjson}}
+            Cette ligne s'affiche autant de fois qu'il y a d'éléments dans la liste.
+            <li>{{.}}</li>
+        {{/monchampjson}}
+
+Exemple 2 pour *monchampjson* = ``[{"nom": "item1", "code": 1}, {"nom": "item2", "code": 2}]``
+
+.. code-block:: xml
+       :linenos:
+
+        {{#monchampjson}}
+            Cette ligne s'affiche autant de fois qu'il y a d'éléments dans la liste.
+            <li>{{nom}} - {{code}}</li>
+        {{/monchampjson}}
+
+Exemple 3 pour afficher un tableau
+
+.. code-block:: xml
+       :linenos:
+
+        <table>
+            <thead>
+                <tr><th>NOM</th><th>CODE</th></tr>
+            </thead>
+            <tbody>
+                {{#communes}}
+                    <tr><td>{{nom}}</td><td>{{code_insee}}</td></tr>
+                {{/communes}}
+            </tbody>
+        </table>
+
+Résultat du template ci dessus
+-------------------------------
+
+.. image:: ../_images/dev/config_tpl/exemple_template_table.png
+              :width: 400
+              :alt: Exemple de template
+              :align: center
+
 
 Itérer sur les champs disponibles
 ---------------------------------

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -648,6 +648,12 @@ var configuration = (function () {
                         }
                     }
 
+                    if (layer.jsonfields) {
+                        oLayer.jsonfields = layer.jsonfields.split(",");
+                    } else {
+                        oLayer.jsonfields = [];
+                    }
+
                     if (layer.scalemin || layer.scalemax) {
                         oLayer.scale = {};
                         if (layer.scalemin) {

--- a/js/info.js
+++ b/js/info.js
@@ -291,7 +291,7 @@ var info = (function () {
         /**
          * Return infos according to map click event behavior.
          * This callback is return when all request are resolved (like promiseAll behavior)
-         * @param {object} result 
+         * @param {object} result
          */
         var callback = function (result) {
             $.each(featureInfoByLayer, function (index, response) {
@@ -717,6 +717,15 @@ var info = (function () {
 
     var applyTemplate = function (olfeatures, olayer) {
         var tpl = olayer.template;
+        var _json = function (str) {
+            var result = null;
+            try {
+                result = JSON.parse(str);
+            } catch (e) {
+                result = str;
+            }
+            return result;
+        };
         var obj = {features: []};
         var activeAttributeValue = false;
         // if attributeControl is used for this layer, get the active attribute value and
@@ -726,11 +735,19 @@ var info = (function () {
             activeAttributeValue = activeFilter.split(olayer.attributeoperator).map(e=>e.replace(/[\' ]/g, ''))[1];
         }
         olfeatures.forEach(function(feature){
+            olayer.jsonfields.forEach(function (fld) {
+                if (feature.get(fld)) {
+                    var json = _json(feature.get(fld));
+                    // convert String value to JSON value
+                    // Great for use in Mustache template
+                    feature.set(fld,json);
+                }
+            });
             if (activeAttributeValue) {
                 feature.set(activeAttributeValue, true);
             }
             var geometryName = feature.getGeometryName();
-            var excludedPropNames = ['fields_kv', 'serialized', 'feature_ol_uid', 'mviewerid', geometryName]
+            var excludedPropNames = ['fields_kv', 'serialized', 'feature_ol_uid', 'mviewerid', geometryName];
             var extractFeaturePropertiesFn = function (properties) {
                 return Object.keys(properties).reduce((filteredProps, propertyName) => {
                     var value = properties[propertyName];


### PR DESCRIPTION
### This PR allows convert String fields to JSON fields. 
This is neccessary to iterate over list items in Mustache templates

Demo in demo/jsonlayers.xml

### How to use it ?

- First create a field named **mylist** in your data with **String** value like 

```
"[
    {"name": "SRFC", "league": 1},
    {"name": "FCNA", "league": 2}
]"
```

- Then in config.xml, add this parameter in the layer configuration `jsonfields="mylist"`

 - Finally, update your template with this section

```
<table style="width:100%;">
    <thead>
        <tr>
            <th>CLUB</th>
            <th>LIGUE</th>

        </tr>
    </thead>
    <tbody>
        {{#mylist}}
            <tr>
                <td>{{name}}</td>
                <td>{{league}}</td>
            </tr>
          {{/mylist}}
    </tbody>
</table> 
```
