### PR TITLE
Titre en HTML ou classique

### DIFF
--- a/.github/ISSUE_TEMPLATE/evolution.md
+++ b/.github/ISSUE_TEMPLATE/evolution.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-**Description détaillée / Describe**
+**Description / Describe**
 
 Une courte et description de ce que vous voulez.
 Cela peut toucher une fonctionnalité qui existe (ex: améliorer un outil de mesure) ou l'ajout d'une nouvelle fonctionnalité qui n'existe pas dans le Mviewer.

--- a/docs/doc_tech/config_app.rst
+++ b/docs/doc_tech/config_app.rst
@@ -14,7 +14,9 @@ Personnalisation de l'application
 .. code-block:: xml
        :linenos:
 
-	<application title=""
+	<application
+		titlehtml=""
+		title=""
 		logo=""
 		help=""
 		showhelp=""
@@ -41,6 +43,7 @@ Personnalisation de l'application
 
 **Paramètres**
 
+* ``titlehtml`` :guilabel:`studio` : optionnel de type texte, il permet d'utiliser du HTML uniquement pour le titre de l'application. Utiliser **title** avec ce paramètre pour le titre de l'onglet et la page de chargement.
 * ``title`` :guilabel:`studio` : paramètre optionnel de type texte qui définit le titre de l'application. Valeur par défaut **mviewer**.
 * ``logo`` :guilabel:`studio` : paramètre optionnel de type url qui définit l'emplacement du logo de l'application. Valeur par défaut **img/logo/earth-globe.svg**.
 * ``help`` :guilabel:`studio` : paramètre optionnel de type url qui définit l'emplacement du fichier html de l'aide.

--- a/index.html
+++ b/index.html
@@ -546,7 +546,8 @@
                         var title = "";
                         if (_conf.application.title) {
                             title = _conf.application.title;
-                            $("#loader-subtitle").text(title);
+                            $("#loader-subtitle").empty();
+                            $("#loader-subtitle").append(title);
                         }
                         if (_conf.application.favicon) {
                             let ico = _conf.application.favicon;

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -231,7 +231,9 @@ var configuration = (function () {
         if (conf.application.title || API.title) {
             var title = API.title || conf.application.title;
             document.title = title;
-            $(".mv-title").text(title);
+            title = conf.application.htmltitle || title;
+            $(".mv-title").text("");
+            $(".mv-title").append(title);
         }
         if (conf.application.stats === "true" && conf.application.statsurl) {
             $.get(conf.application.statsurl +"?app=" + document.title);


### PR DESCRIPTION
#512

### Modifications apportées

* Pour le titre

Nouveau paramètre documenté afin d'ajouter un HTML simple comme titre. Si non renseigné, le paramètre natif `title` est utilisé.
Utilisation d'un `append` à la place d'un `.text()`

Cela permet également d'avoir un texte vide dans le titre (impossible actuellement) via une div avec un texte transparent.

* Pour le loader

Utilisation d'un `append` à la place d'un `.text()`

* Template issue type Enhancement
 
Suppression d'un doublon dans le template de demande d'évolution

* Doc

Nouveau paramètre `titlehtml` pour la section [configuration de l'application](https://mviewerdoc.readthedocs.io/fr/latest/doc_tech/config_app.html?highlight=title%3D)



### Exemple d'utilisation 

**1. Définir et encoder son HTML ([site d'encodage HTML](https://www.convertstring.com/fr/EncodeDecode/HtmlEncode))**

```
    <span style="background-color: #19bbb6 !important; font-size: 18px">Foo Bar</span><p style="font-size: 12px">
    Lorem ipsum dolor sit amet</p>
```

Devient 

```
    &lt;span style=&quot;background-color: #19bbb6 !important; font-size: 18px&quot;&gt;Foo Bar&lt;/span&gt;&lt;p style=&quot;font-size: 12px&quot;&gt;
    Lorem ipsum dolor sit amet&lt;/p&gt;
```

**2. Paramétrer son application**

```
  htmltitle="&lt;span style=&quot;background-color: #19bbb6 !important; font-size: 18px&quot;&gt;Foo BarEiffel&lt;/span&gt;&lt;p style=&quot;font-size: 12px&quot;&gt;
    Lorem ipsum dolor sit amet&lt;/p&gt;"
  title="Lorem Ipsum"
```

**3. Apperçu**

![image](https://user-images.githubusercontent.com/16317988/132240425-ab4648d2-0737-4907-b51e-ed467e271144.png)


le loader et l'onglet (document.title) conserve le texte de la propriété `title`.