### PR TITLE
#547 baselayer et type de valeur d'opacité

### DIFF
--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -1088,7 +1088,7 @@ mviewer = (function () {
         var l;
         function setBaseOpacity(layer, value){
             if(layer && value) {
-                layer.setOpacity(value);
+                layer.setOpacity(Number(value));
             }
         }
         switch (baselayer.type) {


### PR DESCRIPTION
Force l'utilisation du type `Number` pour la valeur du paramètre `opacity` d'une baselayer.

https://openlayers.org/en/latest/apidoc/module-ol_layer_Base-BaseLayer.html#setOpacity