### PR TITLE
#397 - Update cluster customlayer and fix cluster highlight

### DIFF
--- a/customlayers/cluster.js
+++ b/customlayers/cluster.js
@@ -1,117 +1,144 @@
-{
-    mviewer.customLayers.cluster = {};
-    var cl = mviewer.customLayers.cluster;
-    cl.legend = { items:[] };
-    var uniqueStyle = [
+const GEOSERVER_URL = "https://geobretagne.fr/geoserver";
+const WORKSPACE = "dreal_b";
+const LAYER_URL = `${GEOSERVER_URL}/${WORKSPACE}/wfs?service=WFS&version=1.0.0&request=GetFeature&typeNames=dreal_b:projets-environnement-diffusion&outputFormat=application/json&srsName=EPSG:4326&bbox=-6,47,0,49`;
+const LAYER_ID = "cluster";
+
+// create styles
+const uniqueStyle = [
+    new ol.style.Style({
+        image: new ol.style.Circle({
+            radius: 10,
+            fill: new ol.style.Fill({
+                color: 'rgba(231, 76, 60, 0.7)'
+            })
+        })
+    }),
+    new ol.style.Style({
+        image: new ol.style.Circle({
+            radius: 8,
+            fill: new ol.style.Fill({
+                color: 'rgba(236, 240, 241,7.0)'
+            })
+        })
+    })
+];
+const clusterStyle = function(feature) {
+    var size = feature.get('features').length;
+    var max_radius = 40;
+    var max_value = 500;
+    var radius = 10 + Math.sqrt(size)*(max_radius / Math.sqrt(max_value));
+    var radius2 = radius *80 /100 ;
+    if (size == 1) {
+        return uniqueStyle;
+    } else {
+        return manyStyle(radius, radius2, size);
+    }
+};
+const manyStyle = function (radius, radius2, size) {
+    return [
         new ol.style.Style({
             image: new ol.style.Circle({
-                radius: 10,
+                radius: radius,
                 fill: new ol.style.Fill({
-                    color: 'rgba(231, 76, 60, 0.7)'
+                    color: 'rgba(236, 240, 241,0.7)'
                 })
-            })
+            }),
+            stroke: new ol.style.Stroke({
+                color: 'red',
+                width: 3
+          }),
+          fill: new ol.style.Fill({
+            color: 'rgba(0, 0, 255, 0.1)'
+          })
         }),
         new ol.style.Style({
             image: new ol.style.Circle({
-                radius: 8,
+                radius: radius2,
                 fill: new ol.style.Fill({
-                    color: 'rgba(236, 240, 241,7.0)'
+                    color: 'rgba(231, 76, 60, 0.7)'
+                })
+            }),
+            text: new ol.style.Text({
+                font: '12px roboto_regular, Arial, Sans-serif',
+                text: size.toString(),
+                fill: new ol.style.Fill({
+                    color: '#fff'
                 })
             })
         })
     ];
-    cl.legend.items.push({styles:uniqueStyle, label: "Dossier", geometry: "Point"});
-    var manyStyle = function (radius, radius2, size) {
-        return [
-            new ol.style.Style({
-                image: new ol.style.Circle({
-                    radius: radius,
-                    fill: new ol.style.Fill({
-                        color: 'rgba(236, 240, 241,0.7)'
-                    })
-                }),
-                stroke: new ol.style.Stroke({
-                    color: 'red',
-                    width: 3
-              }),
-              fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 255, 0.1)'
-              })
-            }),
-            new ol.style.Style({
-                image: new ol.style.Circle({
-                    radius: radius2,
-                    fill: new ol.style.Fill({
-                        color: 'rgba(231, 76, 60, 0.7)'
-                    })
-                }),
-                text: new ol.style.Text({
-                    font: '12px roboto_regular, Arial, Sans-serif',
-                    text: size.toString(),
-                    fill: new ol.style.Fill({
-                        color: '#fff'
-                    })
-                })
-            })
-        ];
-    };
-    cl.legend.items.push({styles:manyStyle(10,10,7), label: "Groupe de dossiers", geometry: "Point"});
+};
 
-    var clusterStyle = function(feature) {
-        var size = feature.get('features').length;
-        var max_radius = 40;
-        var max_value = 500;
-        var radius = 10 + Math.sqrt(size)*(max_radius / Math.sqrt(max_value));
-        var radius2 = radius *80 /100 ;
-        if (size == 1) {
-            return uniqueStyle;
+// create legend
+const legend = {
+    items: [
+        {styles: uniqueStyle, label: "Dossier", geometry: "Point"},
+        {styles: manyStyle(10,10,7), label: "Groupe de dossiers", geometry: "Point"}
+    ]
+};
+
+let layer = new ol.layer.Vector({
+    source: new ol.source.Cluster({
+        geometryFunction: function(feature) {
+            return new ol.geom.Point(ol.extent.getCenter(feature.getGeometry().getExtent()));
+        },
+        distance: 50,
+        source: new ol.source.Vector({
+            url: LAYER_URL,
+            format: new ol.format.GeoJSON()
+        })
+    }),
+    style: clusterStyle
+});
+
+const handle = function(clusters, views) {
+    if (clusters.length > 0) {
+        var l = mviewer.getLayer(LAYER_ID);
+        var elements = [];
+        var html;
+        var panel = "";
+        clusters.forEach(c => {
+            // ICI ON CREER MANUELLEMENT LES FEATURES POUR MUSTACHE ET LE TEMPLATE POUR V3.5 ET ANTERIEUR
+            if (c?.properties) {
+                // v<3.5
+                elements = elements.concat(
+                    c.properties.features.map(d =>
+                        ({
+                            properties: d.getProperties()
+                        })
+                    )
+                )
+            } else {
+                // v>=3.5
+                elements = elements.concat(
+                    c?.getProperties()?.features || c.properties.features
+                );
+            }
+        });
+        // Création du HTML à partir du template et des features issues de la manipulation des données
+        if (l.template) {
+            html = info.templateHTMLContent(elements, l);
         } else {
-            return manyStyle(radius, radius2, size);
+            html = info.formatHTMLContent(elements, l);
         }
-    };
-
-    cl.layer = new ol.layer.Vector({
-        source: new ol.source.Cluster({
-            geometryFunction: function(feature) {
-                return new ol.geom.Point(ol.extent.getCenter(feature.getGeometry().getExtent()));
-            },
-            distance: 50,
-            source: new ol.source.Vector({
-                url: "https://geobretagne.fr/geoserver/dreal_b/wfs?service=WFS&version=1.0.0&request=GetFeature&typeNames=dreal_b:projets-environnement-diffusion&outputFormat=application/json&srsName=EPSG:4326&bbox=-6,47,0,49",
-                format: new ol.format.GeoJSON()
-            })
-        }),
-        style: clusterStyle
-
-    });
-    cl.handle = function(clusters, views) {
-        if (clusters.length > 0 && clusters[0].getProperties().features) {
-            var features = clusters[0].getProperties().features;
-            var l = mviewer.getLayer("cluster");
-            var html;
-            if (l.template) {
-                html = info.templateHTMLContent(features, l);
-            } else {
-                html = info.formatHTMLContent(features, l);
-            }
-            var panel = "";
-            if (configuration.getConfiguration().mobile) {
-                panel = "modal-panel";
-            } else {
-                panel = "right-panel"
-            }
-            var view = views[panel];
-            view.layers.push({
-                "id": view.layers.length + 1,
-                "firstlayer": true,
-                "manyfeatures": (features.length > 1),
-                "nbfeatures": features.length,
-                "name": l.name,
-                "layerid": "cluster",
-                "theme_icon": l.icon,
-                "html": html
-            });
+        // force l'affichage selon le mode mobile ou desktop
+        if (configuration.getConfiguration().mobile) {
+            panel = "modal-panel";
+        } else {
+            panel = "right-panel"
         }
+        var view = views[panel];
+        view.layers.push({
+            "id": view.layers.length + 1,
+            "firstlayer": true,
+            "manyfeatures": (elements.length > 1),
+            "nbfeatures": elements.length,
+            "name": l.name,
+            "layerid": LAYER_ID,
+            "theme_icon": l.icon,
+            "html": html
+        });
+    }
+};
 
-    };
-}
+new CustomLayer(LAYER_ID, layer, legend, handle);

--- a/js/info.js
+++ b/js/info.js
@@ -452,14 +452,16 @@ var info = (function () {
                     // init sub selection
                     _firstlayerFeatures = _queriedFeatures.filter(feature => {
                         return feature.get("mviewerid") == view.layers[0].layerid;
-                    })
+                    });
                     // change feature of sub selection
                     $('.carousel.slide').on('slide.bs.carousel', function (e) {
                         $(e.currentTarget).find(".counter-slide").text($(e.relatedTarget).attr("data-counter"));
                         var selectedFeature = _queriedFeatures.filter(feature => {
                             return feature.ol_uid == e.relatedTarget.id;
                         })
-                        mviewer.highlightSubFeature(selectedFeature[0]);
+                        if (!_queriedFeatures[0].get("features")) {
+                            mviewer.highlightSubFeature(selectedFeature[0]);
+                        }
                     });
                     // change layer of sub selection
                     if (configuration.getConfiguration().mobile) {
@@ -475,8 +477,13 @@ var info = (function () {
                     $('#'+panel).removeClass("active");
                 }
                 // highlight features and sub feature
-                mviewer.highlightFeatures(_queriedFeatures);
-                mviewer.highlightSubFeature(_firstlayerFeatures[0]);
+                if(_queriedFeatures[0] && _queriedFeatures[0].get("features")) {
+                    // cluster
+                    mviewer.highlightSubFeature(_queriedFeatures[0]);
+                } else {
+                    mviewer.highlightFeatures(_queriedFeatures);
+                    mviewer.highlightSubFeature(_firstlayerFeatures[0]);
+                }
                 // show pin as fallback if no geometry for wms layer
                 if (showPin || (!_queriedFeatures.length && !_firstlayerFeatures.length && !isClick)) {
                     mviewer.showLocation(_projection.getCode(), _clickCoordinates[0], _clickCoordinates[1], !showPin ? search.options.banmarker : showPin);


### PR DESCRIPTION
#397 

Cette PR contient :

- Update du custom layer pour utiliser une classz CustomLayer
- Affiche la surbrillance pour la feature du cluster en style principal et non comme une sélection secondaire
- Ne pas changer de géométrie au clic sur un chevron (slide) car on a qu'une géométrie sur la carte (=>le cluster)