### PR TITLE
#567 toolbar et boutons de zoom paramétrables

### DIFF
--- a/docs/doc_tech/config_app.rst
+++ b/docs/doc_tech/config_app.rst
@@ -25,6 +25,8 @@ Personnalisation de l'application
 		style=""
 		exportpng=""
 		measuretools=""
+		zoomtools=""
+		initialextenttool=""
 		stats=""
 		statsurl=""
 		coordinates=""
@@ -53,6 +55,8 @@ Personnalisation de l'application
 * ``style`` :guilabel:`studio` : paramètre optionnel de type url précisant la feuille de style à utiliser afin de modifier l'apparence de l'application (couleurs, polices...). Valeur par défaut **css/themes/default.css**. Voir : ":ref:`configcss`".
 * ``exportpng`` :guilabel:`studio` : paramètre optionnel de type booléen (true/false) activant l'export de la carte en png. Valeur par défaut **false**. Attention l'export ne fonctionne qu'avec des couches locales (même origine) ou avec des couches servies avec  `CORS <https://enable-cors.org/>`_ activé.
 * ``measuretools`` :guilabel:`studio` : paramètre optionnel de type booléen (true/false) activant les outils de mesure. Valeur par défaut **false**.
+* ``zoomtools`` : paramètre optionnel de type booléen (true/false) activant les outils de zoom +/-. Valeur par défaut **true**.
+* ``initialextenttool`` : paramètre optionnel de type booléen (true/false) activant le bouton de retour à l'étendue initiale. Valeur par défaut **true**.
 * ``stats``: paramètre optionnel de type booléen (true/false) activant l'envoi de stats d'utilisation l'application. Valeur par défaut **false**.
 * ``statsurl``: paramètre optionnel de type url précisant l'url du service reccueillant les données d'utilisation de l'application (ip, application title, date). Ce service n'est pas proposé dans mviewer.
 * ``coordinates`` :guilabel:`studio` : paramètre optionnel de type booléen (true/false) activant l'affichage des coordonnées GPS ( navbar) lors de l'interrogation. Valeur par défaut **false**.

--- a/index.html
+++ b/index.html
@@ -214,21 +214,6 @@
             <div id="mviewerinfosbar" class="hidden-xs">
                 <span id="powered" i18n="infos.powered">Propulsé par </span> <a class="mviewer-link" href="https://mviewer.netlify.app/fr/" target="_blank">mviewer</a>
             </div>
-            <!-- FIRST VERTICAL RIGHT TOOLBAR -->
-            <div id="zoomtoolbar" class="btn-group-vertical btn-group-sm" role="group" aria-label="true">
-                <button href="#" onclick="mviewer.zoomIn();" i18n="tbar.right.zoom.in" title="Zoom avant (zoom fenêtre : shift + clic sur la carte)"
-                    class="btn btn-default btn-raised" tabindex="104" accesskey="4" >
-                     <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
-                </button>
-                <button href="#" onclick="mviewer.zoomToInitialExtent();"
-                    title="Revenir à l'étendue géographique de départ" i18n="tbar.right.zoom.initial" class="btn btn-default btn-raised" tabindex="105" accesskey="5">
-                     <span class="glyphicon glyphicon-home" aria-hidden="true"></span>
-                </button>
-                <button href="#" onclick="mviewer.zoomOut();" title="Zoom arrière" i18n="tbar.right.zoom.out"
-                    class="btn btn-default btn-raised" tabindex="106" accesskey="6">
-                     <span class="glyphicon glyphicon-minus" aria-hidden="true"></span>
-                </button>
-            </div>
             <!-- SECOND VERTICAL RIGHT TOOLBAR -->
             <div id="toolstoolbar" class="btn-group-vertical btn-group-sm" role="group" aria-label="true">
                 <button data-toggle="modal" data-target="#sharepanel" onclick="mviewer.mapShare();" id="sharebtn" title="Partager cette carte"
@@ -475,6 +460,7 @@
         <script type="text/javascript" src="js/utils.js"></script>
         <script type="text/javascript" src="js/ogcutils.js"></script>
         <script type="text/javascript" src="js/configuration.js"></script>
+        <script type="text/javascript" src="js/zoom.js"></script>
         <script type="text/javascript" src="js/measure.js"></script>
         <script type="text/javascript" src="js/info.js"></script>
         <script type="text/javascript" src="js/search.js"></script>

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -637,14 +637,28 @@ mviewer = (function () {
         //GetFeatureInfo tool
         mviewer.tools.info = info;
         mviewer.tools.info.init();
+        const appconfig = configuration.getConfiguration().application;
+
         //Measure tool
-        if (configuration.getConfiguration().application.measuretools === "true") {
-            //Load measure moadule
+        if (appconfig.measuretools === "true") {
+            //Load measure module
             mviewer.tools.measure = measure;
             mviewer.tools.measure.init();
         }
+
         //Activate GetFeatureInfo tool
         mviewer.setTool('info');
+        
+        //Measure tools
+        const zoomBtnActivate = appconfig.zoomtools === "true" || !appconfig.zoomtools;
+        const zoomToExtentBtnActivate = appconfig.initialextenttool === "true" || !appconfig.initialextenttool;
+        if (zoomToExtentBtnActivate || zoomBtnActivate) {
+            //Load zoom toolbar module if one of button is activate
+            mviewer.tools.zoom = zoom;
+            zoom.init();
+        }
+        if (zoomToExtentBtnActivate) zoom.initExtentBtn();
+        if (zoomBtnActivate) zoom.initZoomBtn();
     };
 
     var _initShare = function () {
@@ -1797,26 +1811,6 @@ mviewer = (function () {
                 mviewer.tools.info.enable();
                 mviewer.tools.activeTool = 'info';
             }
-        },
-
-        /**
-         * Public Method: zoomOut
-         *
-         */
-
-        zoomOut: function () {
-           var v = _map.getView();
-           v.animate({zoom: v.getZoom() - 1});
-        },
-
-        /**
-         * Public Method: zoomIn
-         *
-         */
-
-        zoomIn: function () {
-            var v = _map.getView();
-            v.animate({zoom: v.getZoom() + 1});
         },
 
         /**

--- a/js/zoom.js
+++ b/js/zoom.js
@@ -1,0 +1,101 @@
+var zoom = (function() {
+    /**
+     * Property: _map
+     *  @type {ol.Map}
+     */
+
+    let _map;
+    /**
+     * Convert string to HTML DOM node element reusable
+     * @private
+     * @param {string} is html string element
+     */
+    var stringToHTML = function(str) {
+        var parser = new DOMParser();
+        var doc = parser.parseFromString(str, 'text/html');
+        return doc.body.firstChild;
+    };
+
+    /**
+     * Public Method: zoomIn
+     * @public
+     */
+    let changeZoom = toValue => _map.getView().animate({
+        zoom: _map.getView().getZoom() + toValue
+    });
+    const buttonIn =
+        `<button 
+            href="#"
+            onclick="mviewer.tools.zoom.changeZoom(1)"
+            i18n="tbar.right.zoom.in"
+            title="Zoom avant (zoom fenêtre : shift + clic sur la carte)"
+            class="btn btn-default btn-raised" tabindex="104" accesskey="4" >
+            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+        </button>`;
+
+    /**
+     * Button to zoom -
+     * @private
+     */
+    const buttonOut =
+        `<button href="#"
+            onclick="mviewer.tools.zoom.changeZoom(-1)"
+            title="Zoom arrière"
+            i18n="tbar.right.zoom.out"
+            class="btn btn-default btn-raised"
+            tabindex="106" accesskey="6">
+            <span class="glyphicon glyphicon-minus" aria-hidden="true"></span>
+        </button>`;
+
+    /**
+     * Button zoom to initial extent
+     * @private
+     */
+    const buttonZoomToInitialExtent =
+        `<button href="#" onclick="mviewer.zoomToInitialExtent();"
+            title="Revenir à l'étendue géographique de départ" i18n="tbar.right.zoom.initial" class="btn btn-default btn-raised" tabindex="105" accesskey="5">
+            <span class="glyphicon glyphicon-home" aria-hidden="true"></span>
+        </button>`;
+
+    /**
+     * Button zoom toolbar
+     * @private
+     */
+    const zoomToolbar = `
+        <div id="zoomtoolbar" class="btn-group-vertical btn-group-sm" role="group" aria-label="true">
+        </div>
+    `;
+
+    /**
+     * Init zoom buttons
+     * @public
+     */
+    const initZoomBtn = () => {
+        // add buttons to DOM
+        document.getElementById("zoomtoolbar").prepend(stringToHTML(buttonIn));
+        document.getElementById("zoomtoolbar").append(stringToHTML(buttonOut));
+    };
+
+    /**
+     * Init zoom toolbar
+     * @public
+     */
+    const initTbar = () => {
+        _map = mviewer.getMap();
+        document.getElementById("mviewerinfosbar").after(stringToHTML(zoomToolbar));
+    };
+
+    /**
+     * Init zoom to initial extent button
+     * @public
+     */
+    const initZoomToInitExtent = () => {
+        document.getElementById("zoomtoolbar").firstChild.after(stringToHTML(buttonZoomToInitialExtent));
+    }
+    return {
+        init: initTbar,
+        initExtentBtn: initZoomToInitExtent,
+        initZoomBtn: initZoomBtn,
+        changeZoom: changeZoom
+    };
+})();


### PR DESCRIPTION
Liée à #567 et #566.

Cette PR permet de : 
- ajouter les boutons zoom + et - ou de les masquer
- ajouter le bouton de zoom sur l'étendue initiale ou de le masquer

**Paramètres :**
- initialextenttool `<bool>` true par défaut si absent du config.xml
- zoomtools `<bool>` true par défaut si absent du config.xml

**Exemple :**

`<application initialextenttool="true" zoomtools="true"`

