### PR TITLE
#594 - Utilise un overlay ol avec coordonnées

### DIFF
--- a/css/mviewer.css
+++ b/css/mviewer.css
@@ -1653,11 +1653,21 @@ button.btn.btn-default.btn-raised, a#exportpng,a.btn.btn-default {
 }
 
 #feature-info {
-     position: absolute;
-     height: 1px;
-     width: 1px;
-     z-index: 100;
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  z-index: 100;
  }
+ #feature-info .popover-content {
+  color: white !important;
+  padding: 10px !important;
+}
+ #feature-info .popover {
+  background-color: black !important;
+}
+#feature-info .arrow:after {
+  border-top-color: black !important;
+} 
 
 /*******************************
 ------------- HELP PANEL

--- a/css/mviewer.css
+++ b/css/mviewer.css
@@ -1495,6 +1495,7 @@ span.mv-time-player-selection {
 .popover-content{
 	font-size: 13px;
 	color: #555;
+  width: max-content;
 }
 
 .popover-content a{
@@ -1658,16 +1659,6 @@ button.btn.btn-default.btn-raised, a#exportpng,a.btn.btn-default {
   width: 1px;
   z-index: 100;
  }
- #feature-info .popover-content {
-  color: white !important;
-  padding: 10px !important;
-}
- #feature-info .popover {
-  background-color: black !important;
-}
-#feature-info .arrow:after {
-  border-top-color: black !important;
-} 
 
 /*******************************
 ------------- HELP PANEL

--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@
                             <ul id="layers-container" class="list-group"></ul>
                         </div>
                     </div>
-                    <div id="feature-info" class=""></div>
+                    <div id="feature-info"></div>
                     <!-- BOTTOM PANEL -->
                     <div id="bottom-panel">
                         <div id="bottom-panel-btn" ><i class="mv-close fas fa-chevron-down" title="Fermer ce panneau" i18n="bottom.panel.close" onclick="$('#bottom-panel').toggleClass('active')" ></i></div>

--- a/js/info.js
+++ b/js/info.js
@@ -632,7 +632,8 @@ var info = (function () {
                 placement: 'top',
                 animation: false,
                 html: true,
-                content: `${title}`,
+                content: title,
+                template: mviewer.templates.tooltip
             });
             $(popup).popover('show');
         }

--- a/js/info.js
+++ b/js/info.js
@@ -424,7 +424,9 @@ var info = (function () {
 
                     if (configuration.getConfiguration().mobile) {
                         $("#modal-panel").modal("show");
-                        _featureTooltip.getElement().popover('hide')
+                        if (_featureTooltip.getElement().children.length) {
+                            _featureTooltip.getElement().popover('hide')
+                        }
                     } else {
                         if (!$('#'+panel).hasClass("active")) {
                             $('#'+panel).toggleClass("active");
@@ -853,22 +855,6 @@ var info = (function () {
         $.each(_overLayers, function (i, layer) {
             if (layer.queryable && layer.showintoc) {
                 _addQueryableLayer(layer);
-            }
-        });
-        var noTooltipZone = [
-            "#layers-container-box",
-            "#sidebar-wrapper",
-            "#bottom-panel",
-            "#right-panel",
-            "#mv-navbar",
-            "#zoomtoolbar",
-            "#toolstoolbar",
-            "#backgroundlayerstoolbar-default",
-            "#backgroundlayerstoolbar-gallery"
-        ];
-        $(noTooltipZone.join(", ")).on('mouseover', function() {
-            if (_featureTooltip) {
-                _featureTooltip.getElement().popover('hide')
             }
         });
     };

--- a/js/info.js
+++ b/js/info.js
@@ -539,22 +539,20 @@ var info = (function () {
             return;
         }
         if (!_featureTooltip) {
-            _featureTooltip = $('#feature-info');
-            _featureTooltip.tooltip({
-                animation: false,
-                trigger: 'manual',
-                container: 'body',
-                html: true,
-                template: mviewer.templates.tooltip
+            _featureTooltip = new ol.Overlay({
+                element: document.getElementById('feature-info'),
+                offset: [5, -10]
             });
+            mviewer.getMap().addOverlay(_featureTooltip);
         }
-        var pixel = _map.getEventPixel(evt.originalEvent);
-        var _o = mviewer.getLayers();
-        // default tooltip state or reset tooltip
-        _featureTooltip.tooltip('hide');
-        $("#map").css("cursor", "");
+        _featureTooltip.setPosition(evt.coordinate);
+        const popup = _featureTooltip.getElement();
 
-        var feature = _map.forEachFeatureAtPixel(pixel, function (feature, layer) {
+        var pixel = mviewer.getMap().getEventPixel(evt.originalEvent);
+        // default tooltip state or reset tooltip
+        $(popup).popover('hide');
+        $("#map").css("cursor", "");
+        var feature = mviewer.getMap().forEachFeatureAtPixel(pixel, function (feature, layer) {
             if (!layer
                 || layer.get('mviewerid') === 'featureoverlay'
                 || layer.get('mviewerid') === 'selectoverlay'
@@ -593,7 +591,7 @@ var info = (function () {
         //hack to check if feature is yet overlayed
         var newFeature = false;
         if(!feature) {
-            _featureTooltip.tooltip('hide');
+            $(popup).popover('hide');
             $("#map").css("cursor", "");
             _sourceOverlay.clear();
             return;
@@ -630,15 +628,14 @@ var info = (function () {
                     feature.getProperties()["title"] || feature.getProperties()["nom"] ||
                     feature.getProperties()[l.fields[0]]);
             }
-
-            _featureTooltip.css({
-                left: (pixel[0]) + 'px',
-                top: (pixel[1] - 15) + 'px'
+            $(popup).popover({
+                container: popup,
+                placement: 'top',
+                animation: false,
+                html: true,
+                content: `${title}`,
             });
-            _featureTooltip.tooltip('hide')
-                .attr('data-original-title', title)
-                .tooltip('fixTitle')
-                .tooltip('show');
+            $(popup).popover('show');
         }
     };
 

--- a/js/info.js
+++ b/js/info.js
@@ -424,7 +424,7 @@ var info = (function () {
 
                     if (configuration.getConfiguration().mobile) {
                         $("#modal-panel").modal("show");
-                        $("#feature-info").tooltip("hide");
+                        _featureTooltip.getElement().popover('hide')
                     } else {
                         if (!$('#'+panel).hasClass("active")) {
                             $('#'+panel).toggleClass("active");
@@ -868,7 +868,7 @@ var info = (function () {
         ];
         $(noTooltipZone.join(", ")).on('mouseover', function() {
             if (_featureTooltip) {
-                $('#feature-info').tooltip('hide');
+                _featureTooltip.getElement().popover('hide')
             }
         });
     };

--- a/js/info.js
+++ b/js/info.js
@@ -550,7 +550,7 @@ var info = (function () {
 
         var pixel = mviewer.getMap().getEventPixel(evt.originalEvent);
         // default tooltip state or reset tooltip
-        $(popup).popover('hide');
+        $(popup).popover('destroy');
         $("#map").css("cursor", "");
         var feature = mviewer.getMap().forEachFeatureAtPixel(pixel, function (feature, layer) {
             if (!layer
@@ -591,7 +591,6 @@ var info = (function () {
         //hack to check if feature is yet overlayed
         var newFeature = false;
         if(!feature) {
-            $(popup).popover('hide');
             $("#map").css("cursor", "");
             _sourceOverlay.clear();
             return;

--- a/js/templates.js
+++ b/js/templates.js
@@ -4,7 +4,7 @@ mviewer.templates = {};
 mviewer.templates.tooltip = [
     '<div class="tooltip mv-tooltip" role="tooltip">',
         '<div class="mv-tooltip tooltip-arrow"></div>',
-        '<div class="mv-tooltip tooltip-inner"></div>',
+        '<div class="mv-tooltip tooltip-inner popover-content"></div>',
     '</div>'].join("");
 
 mviewer.templates.theme = [


### PR DESCRIPTION
**Corrige l'issue #594**

Cette PR permet d'utiliser un un overlay Openlayers pour la tooltip WFS et de ne plus utiliser les pixels mais les coordonnées de la carte pour positionner la popup.

https://openlayers.org/en/latest/apidoc/module-ol_Overlay-Overlay.html
https://openlayers.org/en/latest/examples/overlay.html

La configuration mviewer et le fonctionnement avec le config.xml restent inchangés.

![overlay_mviewer](https://user-images.githubusercontent.com/16317988/164248103-4c4c1044-7d7a-4f07-9520-2d8ba2e35e45.gif)

