### PR TITLE
#603 - Ajout de map-ready event - mineur

### DIFF
--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -339,6 +339,13 @@ mviewer = (function () {
             })
         });
 
+        const mapReadyEvent = new CustomEvent('map-ready', {
+            detail: {
+              map: _map
+            }
+        });
+        document.dispatchEvent(mapReadyEvent);
+
          _map.on('moveend', _mapChange);
         //Handle zoom change
         _map.getView().on('change:resolution', _mapZoomChange);


### PR DESCRIPTION
Ref. #603 

Cet event `map-ready` map-ready permet à différents `listeners `(e.g extensions) de savoir quand la carte sera disponible.

Modification impactante : aucune.