### PR TITLE
Couche interrogeable mais qui n'est pas dans la toc

### DIFF
--- a/js/info.js
+++ b/js/info.js
@@ -853,7 +853,7 @@ var info = (function () {
         }
         _sourceOverlay = mviewer.getSourceOverlay();
         $.each(_overLayers, function (i, layer) {
-            if (layer.queryable && layer.showintoc) {
+            if (layer.queryable) {
                 _addQueryableLayer(layer);
             }
         });


### PR DESCRIPTION
Code de l'issue #641 : pouvoir interroger une couche qui n'est pas visible dans la toc