### PR TITLE
tri fiches infos selon la toc

### DIFF
--- a/docs/doc_tech/config_app.rst
+++ b/docs/doc_tech/config_app.rst
@@ -43,6 +43,7 @@ Syntaxe
 		lang=""
 		langfile=""
 		favicon=""
+		sortlayersinfopanel=""
         />
 
 Paramètres principaux
@@ -80,6 +81,7 @@ Paramètres secondaires
 * ``lang``: Langue à utiliser pour l'interface. Passer "?lang=en" dans l'url pour forcer la langue et ignorer la config. Par défaut, lang n'est pas activé. Le fichier mviewer.i18n.json contient les expressions à traduire dans différentes langues. Pour traduire le texte d'un élément html, il faut que cet élément dispose d'un attribut i18n=texte.a.traduire. En javascript la traduction s'appuie sur la méthode mviewer.tr("texte.a.traduire").
 * ``langfile``: URL du fichier de traduction supplémentaire à utiliser en complément de mviewer.i18n.json.
 * ``favicon``: URL du fichier image à utiliser comme favicon de l'application.
+* ``sortlayersinfopanel``: mode de tri des couches dans le panneau d'information en suivant la légende qui suit l'ordre des couches de la map (valeur **default**) ou la toc (valeur **toc**). Valeur par défaut **default**.
 
 
 Exemple

--- a/js/info.js
+++ b/js/info.js
@@ -304,13 +304,13 @@ var info = (function () {
             if (configuration.getConfiguration().application.sortlayersinfopanel && configuration.getConfiguration().application.sortlayersinfopanel=='toc'){ //toc order
                 // les couches de la toc dans l'ordre 
                 for (var j = 0; j < infoLayers.length; j++) {// layers not shown in toc but queried first
-                    if (_tocsertedlayers.indexOf(infoLayers[j].initiallayerid ? infoLayers[j].initiallayerid:infoLayers[j].layerid) === -1){
+                    if (_tocsortedlayers.indexOf(infoLayers[j].initiallayerid ? infoLayers[j].initiallayerid:infoLayers[j].layerid) === -1){
                         orderedlayers.push(infoLayers[j]);
                     }
                 }
-                for (var i = 0; i < _tocsertedlayers.length; i++) {
+                for (var i = 0; i < _tocsortedlayers.length; i++) {
                     for (var j = 0; j < infoLayers.length; j++) {
-                        if ((infoLayers[j].initiallayerid ? infoLayers[j].initiallayerid:infoLayers[j].layerid) == _tocsertedlayers[i]){
+                        if ((infoLayers[j].initiallayerid ? infoLayers[j].initiallayerid:infoLayers[j].layerid) == _tocsortedlayers[i]){
                             orderedlayers.push(infoLayers[j]);
                         }
                     }
@@ -869,7 +869,7 @@ var info = (function () {
         _projection = mviewer.getProjection();
         _overLayers = mviewer.getLayers();
         _captureCoordinatesOnClick = configuration.getCaptureCoordinates();
-        _tocsertedlayers = $(".mv-nav-item").map(function() {
+        _tocsortedlayers = $(".mv-nav-item").map(function() {
                 return $(this).attr('data-layerid');
             }).get();
         if (configuration.getConfiguration().application.templaterightinfopanel) {

--- a/js/info.js
+++ b/js/info.js
@@ -94,13 +94,19 @@ var info = (function () {
      */
     var _firstlayerFeatures;
 
+     /**
+     * Property: _tocsortedlayers
+     * Array of string
+     * Used to store all layerids sorted according to the toc
+     */
+    var _tocsortedlayers;
+
     /**
      * Private Method: _customizeHTML
      * @param html {Array}
      * @param featurescount {Integer}
      *
      */
-
     var _customizeHTML = function (html, featurescount) {
         //manipulate html to activate first item.
         var tmp = document.createElement('div');
@@ -293,7 +299,26 @@ var info = (function () {
             viewsLayers.forEach(lv => {
                 mapLayersOrder[mapLayers.indexOf(lv.layerid)] = lv;
             })
-            return mapLayersOrder.filter(f => f).reverse();
+                        var infoLayers = mapLayersOrder.filter(f => f);
+            var orderedlayers = [];
+            if (configuration.getConfiguration().application.sortlayersinfopanel && configuration.getConfiguration().application.sortlayersinfopanel=='toc'){ //toc order
+                // les couches de la toc dans l'ordre 
+                for (var j = 0; j < infoLayers.length; j++) {// layers not shown in toc but queried first
+                    if (_tocsertedlayers.indexOf(infoLayers[j].initiallayerid ? infoLayers[j].initiallayerid:infoLayers[j].layerid) === -1){
+                        orderedlayers.push(infoLayers[j]);
+                    }
+                }
+                for (var i = 0; i < _tocsertedlayers.length; i++) {
+                    for (var j = 0; j < infoLayers.length; j++) {
+                        if ((infoLayers[j].initiallayerid ? infoLayers[j].initiallayerid:infoLayers[j].layerid) == _tocsertedlayers[i]){
+                            orderedlayers.push(infoLayers[j]);
+                        }
+                    }
+                }
+            } else { // ordered with legend (=map order)
+                orderedlayers = infoLayers.reverse();
+            }
+            return orderedlayers
         }
 
         /**
@@ -844,6 +869,9 @@ var info = (function () {
         _projection = mviewer.getProjection();
         _overLayers = mviewer.getLayers();
         _captureCoordinatesOnClick = configuration.getCaptureCoordinates();
+        _tocsertedlayers = $(".mv-nav-item").map(function() {
+                return $(this).attr('data-layerid');
+            }).get();
         if (configuration.getConfiguration().application.templaterightinfopanel) {
             _panelsTemplate["right-panel"] = configuration.getConfiguration().application.templaterightinfopanel;
             _panelsTemplate["modal-panel"] = configuration.getConfiguration().application.templaterightinfopanel;


### PR DESCRIPTION
Code pour l'issue #644 qui permet d'ordonner les couches des panneaux d'information selon l'ordre de la toc au lieu de l'ordre des couches de la map