### PR TITLE
Utilisation de Prettier - format seulement

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+*.min*
+*.css
+*.mst
+**/lib
+**/.git

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+	"trailingComma": "es5",
+	"tabWidth": 4,
+	"useTabs": true,
+	"semi": true,
+	"singleQuote": false,
+	"printWidth": 100,
+	"bracketSpacing": true,
+	"bracketSameLine": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"[javascript]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"editor.formatOnSave": false
+}

--- a/docs/doc_contrib/contrib.rst
+++ b/docs/doc_contrib/contrib.rst
@@ -19,6 +19,111 @@ Cependant vous pouvez ressentir le besoin de modifier mviewer pour créer vos pr
 Vous trouverez ici une présentation et des recommandations pour créer vos cartes et vos fonctionnalités sans modifier le cœur (ou presque).
 Vous obtiendrez un mviewer maintenable et vous n'aurez plus l'appréhension de toucher aux mauvais fichiers.
 
+Code style
+---------------------
+
+.. warning::
+    Ne jamais modifier les fichiers présentés ci-dessous, sauf si la modification des règles de style est demandées par la communauté !
+
+Cette section vous permettra de connaître les règles à utiliser lors de l'écriture du code dans mviewer.
+Ces règles permettent d'assurer que les contributions sont uniformes (e.g indentations, longueur de lignes, etc.) et le code de meilleur qualité.
+
+Les règles de style permettent également d'adopter les bonnes règles pour tous afin de faciliter la comparaison des fichiers et les contributions.
+
+**1. Formattage dans VS Code**
+
+Dans VS Code, vous trouverez un fichier `.vscode/settings.json`.
+
+Ce fichier contient des règles de paramétrage de VS Code qui peuvent être réutilisées par défaut par tous les développeur qui utilisent VS Code avec mviewer.
+
+Ce fichier `settings.json` permet de définir le formatter par défaut par type de language.
+
+Il permet aussi d'utiliser le formattage automatique à la sauvegarde : 
+
+::
+
+    "editor.formatOnSave": false
+
+Dans VS Code, si vous n'utilisez pas ce fichier, vous pouvez formatter à la sauvegarde automatiquement via les préférences VS Code décrites plus bas. 
+
+**2. Prettier**
+
+Mviewer utilise `Prettier <https://prettier.io/>`_.
+Nous conseillons d'utiliser l'éditeur Visual Studio Code et son plugin `Prettier - Code formatter <https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode>`_.
+
+* Installation
+
+Via `npm` (voir `ici <https://github.com/geobretagne/mviewer#d%C3%A9ploiement-avec-nodejs>`_ pour installer `npm`):
+
+::
+
+    npm install
+
+A l'ouverture du projet mviewer avec VS Code, le plugin détectera automatiquement les fichiers `.prettierrc` et `.prettierignore`.
+Les règles seront donc automatiquement détectées et vous pourrez alors utiliser `Prettier` pour appliquer les règles de style au code mviewer.
+
+* Fichier .prettierrc
+
+C'est le fichier de configuration de Prettier (format JSON).
+Il contient toutes les règles à utiliser par Prettier.
+
+Ce fichier situé à la racine contient les règles que toute la communauté utilise.
+
+Pour plus d'informations sur la configuration :
+
+https://prettier.io/docs/en/configuration.html
+
+* Fichier .prettierignore
+
+Ce fichier permet d'ignorer certains fichiers ou dossier du code mviewer.
+
+::
+
+    # Ignore artifacts:
+    build
+    coverage
+
+    # Ignore all HTML files:
+    *.html
+
+    # Ignore folders :
+    **/lib
+
+Pour plus d'informations, sur ce fichier :
+
+https://prettier.io/docs/en/ignore.html
+
+**3. Formatter vos fichiers avec Prettier**
+
+Avec VS Code, Le formattage peut être réalisé à la sauvegarde ou à la demande.
+
+- Formattage à la sauvegarde
+
+Vous devez paramétrer votre éditeur pour formatter à la sauvegarde ou utiliser le fichier `.vscode` décrit plus haut.
+
+Avec VS Code, aller dans Fichier > Préférences > Paramètres et rechercher `format on save`.
+Cocher alors `Editor:Format on save` pour activer le formattage à la sauvegarde.
+
+- Formattage à la demande
+
+Avec VS Code, réaliser un clic droit dans le fichier et cliquer sur `mettre en forme le document avec... `.
+Sélectionner alors `Prettier` dans la liste .
+
+- Fromattage via `npm`
+
+Le fichier `/mviewer/package.json` contient une commande `pretty`.
+Cette commande va effectuer un formattage sur les fichiers `.js` et `.json` des répertoires `/js`, `/demo`, `/customcontrols`, `/customlayers`.
+
+::
+
+    "pretty": "prettier --write \"./mviewer.i18n.json\" \"./js/**/*.{js,json}\" \"./demo/**/*.{js,json}\" \"./customcontrols/*.{js,json}\" \"./customlayers/*.{js,json}\""
+
+Elle s'exécute dans le répertoire `/mviewer` comme ceci :
+
+:: 
+
+    npm install
+    npm run pretty
 
 Le cœur de mviewer
 ------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -1067,6 +1067,12 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg=="
     },
+    "prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -1,29 +1,32 @@
 {
-  "name": "mviewer",
-  "version": "3.8.1-snapshot",
-  "description": "Mviewer",
-  "main": "index.html",
-  "scripts": {
-    "start": "live-server --port=5051",
-    "build": "echo This is a very simple mviewer app, there is no bundler or bundling involved!"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/geobretagne/mviewer.git"
-  },
-  "keywords": [
-    "mviewer",
-    "master",
-    "preview",
-    "demo"
-  ],
-  "author": "PSC Mviewer",
-  "license": "GNU General Public License v3.0",
-  "bugs": {
-    "url": "https://github.com/geobretagne/mviewer/issues"
-  },
-  "homepage": ".",
-  "dependencies": {
-    "live-server": "^1.2.2"
-  }
+    "name": "mviewer",
+    "version": "3.10.0-snapshot",
+    "description": "Mviewer",
+    "main": "index.html",
+    "scripts": {
+        "start": "live-server --port=5051",
+        "pretty": "prettier --write \"./mviewer.i18n.json\" \"./js/**/*.{js,json}\" \"./demo/**/*.{js,json}\" \"./customcontrols/*.{js,json}\" \"./customlayers/*.{js,json}\""
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/geobretagne/mviewer.git"
+    },
+    "keywords": [
+        "mviewer",
+        "master",
+        "preview",
+        "demo"
+    ],
+    "author": "PSC Mviewer",
+    "license": "GNU General Public License v3.0",
+    "bugs": {
+        "url": "https://github.com/geobretagne/mviewer/issues"
+    },
+    "homepage": ".",
+    "dependencies": {
+        "live-server": "^1.2.2"
+    },
+    "devDependencies": {
+        "prettier": "^2.7.1"
+    }
 }


### PR DESCRIPTION
> Lié à l'issue https://github.com/geobretagne/mviewer/issues/179

Cette PR permet de formater les fichier avec VSCode à la sauvegarde d'un fichier et ainsi éviter d'avoir des contributions avec des problèmes de style.

Les templates ont été modifiés pour utiliser la syntaxe [template string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals).

La commande suivante permet de formater automatiquement tout le répertoire `mviewer/js`  (les autres fichiers JavaScript sont à formater à la main) : 

`npm run pretty`

... issue de :

```
    "scripts": {
        "start": "live-server --port=5051",
        "pretty": "prettier --write \"./js/**/*.{js,jsx,json}\""
    },
```

## Règles

Les règles définies dans le fichier [.prettierc](url) sont issues de la [doc prettier](https://prettier.io/docs/en/options.html#semicolons) et peuvent évoluer selon le formatage adopté par la communauté.

## Dépendances rajoutés

Paquet `prettier` (npm) :

```
    "devDependencies": {
        "prettier": "^2.7.1"
    }
```

## Actions à mener : 

- [x] Documentation
- [x] Ajout fichier .prettierignore
- [ ] Passage dans les répertoires coeurs
- [ ] Passage dans les JS des démo
- [ ] Revue
- [x] Test
- [x] Conflit de branche
- [x] Prettify répertoire /js