### PR TITLE
filter - corrige les erreurs au chargement

### DIFF
--- a/demo/addons/filter/js/filter.js
+++ b/demo/addons/filter/js/filter.js
@@ -1013,7 +1013,15 @@ var filter = (function() {
   }
 
   return {
-    init: _initFilterTool,
+    init: () => {
+      try {
+        _initFilterTool()
+      } catch (error) { 
+        $(document).on("layersLoaded", () => {
+          _initFilterTool();      
+        });
+      }
+    },
     toggle: _toggle,
     filterFeatures: _filterFeatures,
     layersFiltersParams: _layersFiltersParams,

--- a/demo/addons/filter/js/filter.js
+++ b/demo/addons/filter/js/filter.js
@@ -1016,9 +1016,14 @@ var filter = (function() {
     init: () => {
       try {
         _initFilterTool()
-      } catch (error) { 
+      } catch (error) {
         $(document).on("layersLoaded", () => {
-          _initFilterTool();      
+          try {
+            _initFilterTool();
+          } catch (e) {
+            $(document).on("configurationCompleted", _initFilterTool)
+          }
+          
         });
       }
     },


### PR DESCRIPTION
Cette Pr corrige le comportement décrit dans l'issue 703 et évite d'avoir : 
- les couches pas encore chargées
- la configuration mviewer pas encore chargée