### PR TITLE
#1027 - File import - ajout formats JSON et GeoJSON

### DIFF
--- a/demo/addons/fileimport/README.md
+++ b/demo/addons/fileimport/README.md
@@ -1,10 +1,20 @@
 ## Import de fichier
 
-Cette extension permet d'importer des fichiers de façon temporaire (en local) des fichiers au format `csv` ou `shp`. 
+Cette extension permet d'importer des fichiers de façon temporaire (en local) des fichiers au format `csv` ou `shp` ou `GeoJSON`. 
+
 Les données importées ne sont pas sauvegardées et seront perdues à la fermeture du navigateur.
-Dans le cas du Shapefile, le fichier `.shp` doit se trouver compressé dans un fichier `.zip` qui inclut également 
-un fichier `.dbf` encodé en UTF-8 (pour les attributs) et `.prj` (pour permettre l'interprétation du SRS à l'extension).
+
+### SHP
+
+Dans le cas du Shapefile, le fichier `.shp` doit se trouver compressé dans un fichier `.zip` qui inclut également un fichier `.dbf` encodé en UTF-8 (pour les attributs) et `.prj` (pour permettre l'interprétation du SRS à l'extension).
+
 En cas d'absence du fichier `.prj` l'utilisateur est sollicité d'indiquer le SRS.
+
+### GeoJSON
+
+Correspond au format `.geojson` (type `application/geo+json`).
+
+La projection devra être en `EPSG:4326`. Les fichier JSON (`application/json`) ne sont actuellement pas encore compatible.
 
 #### 4 ressources dans cette extension
 
@@ -60,8 +70,7 @@ Pour les couches csv (avec coordonnées) :
 La définition de chaque projection se fait dans un élément enfant ``<projection proj4js=""/>`` qui contient la chaîne de caractère proj4js comme attribut.
 Par défaut le SCR WGS84 (EPSG:4326) est supporté. L'import d'un shapefile n'utilise pas cette définition, mais l'obtient directement du fichier `.prj`.
 
-Exemple qui rend disponible l'IHM de l'extension, permettant l'import `shp` et `csv` (avec des coordonnées en `EPSG:4326`,`EPSG:3857` ou `EPSG:2154` 
-ou avec adresse et sans coordonnées) :
+Exemple qui rend disponible l'IHM de l'extension, permettant l'import `geojson`, `shp` et `csv` (avec des coordonnées en `EPSG:4326` (obligatoire en GeoJSON), `EPSG:3857` ou `EPSG:2154` ou avec adresse et sans coordonnées) :
 
 ````
 <layer type="import" id="import_file" name="Importer un fichier"  visible="true"

--- a/demo/addons/fileimport/README.md
+++ b/demo/addons/fileimport/README.md
@@ -1,6 +1,6 @@
 ## Import de fichier
 
-Cette extension permet d'importer des fichiers de façon temporaire (en local) des fichiers au format `csv` ou `shp` ou `GeoJSON`. 
+Cette extension permet d'importer des fichiers de façon temporaire (en local) des fichiers au format `csv`, `shp`, `GeoJSON` ou `JSON`. 
 
 Les données importées ne sont pas sauvegardées et seront perdues à la fermeture du navigateur.
 

--- a/demo/addons/fileimport/README.md
+++ b/demo/addons/fileimport/README.md
@@ -10,11 +10,14 @@ Dans le cas du Shapefile, le fichier `.shp` doit se trouver compressé dans un f
 
 En cas d'absence du fichier `.prj` l'utilisateur est sollicité d'indiquer le SRS.
 
-### GeoJSON
+### GeoJSON et JSON
 
-Correspond au format `.geojson` (type `application/geo+json`).
+Correspond aux formats `.geojson` ou `.json` (MIME types `application/geo+json` ou `application/json`).
 
-La projection devra être en `EPSG:4326`. Les fichier JSON (`application/json`) ne sont actuellement pas encore compatible.
+En accord avec le standard GeoJSON, le fichier doit contenir des géométries avec le système de référence  WGS84 (EPSG:4326).
+
+> Specifications du standard  RFC7946 :
+> https://datatracker.ietf.org/doc/html/rfc7946#section-4
 
 #### 4 ressources dans cette extension
 

--- a/demo/addons/fileimport/fileimport.js
+++ b/demo/addons/fileimport/fileimport.js
@@ -196,7 +196,7 @@ const fileimport = (function () {
     }
     if (file) {
       // fix windows OS empty type with .geojson format
-      if (/\.geojson$/i.test(file)) {
+      if (/\.geojson$/i.test(file.name)) {
         file.type = "application/geo+json";
       }
       //remove existing features

--- a/demo/addons/fileimport/fileimport.js
+++ b/demo/addons/fileimport/fileimport.js
@@ -195,6 +195,10 @@ const fileimport = (function () {
       file = document.getElementById("loadcsv-" + idlayer).files[0];
     }
     if (file) {
+      // fix windows OS empty type with .geojson format
+      if (/\.geojson$/i.test(file)) {
+        file.type = "application/geo+json";
+      }
       //remove existing features
       mviewer.getLayers()[idlayer].layer.getSource().clear();
       var oLayer = mviewer.getLayers()[idlayer];

--- a/demo/addons/fileimport/fileimport.js
+++ b/demo/addons/fileimport/fileimport.js
@@ -209,7 +209,7 @@ const fileimport = (function () {
       ];
       if (zipMimeTypes.includes(file.type)) {
         _unzip(file, oLayer);
-      } else if (["application/geo+json"].includes(file.type)) {
+      } else if (["application/geo+json", "application/json"].includes(file.type)) {
         // Load GeoJSON directly
         var reader = new FileReader();
         reader.onload = function (evt) {

--- a/demo/addons/fileimport/fileimport.js
+++ b/demo/addons/fileimport/fileimport.js
@@ -195,10 +195,6 @@ const fileimport = (function () {
       file = document.getElementById("loadcsv-" + idlayer).files[0];
     }
     if (file) {
-      // fix windows OS empty type with .geojson format
-      if (/\.geojson$/i.test(file.name)) {
-        file.type = "application/geo+json";
-      }
       //remove existing features
       mviewer.getLayers()[idlayer].layer.getSource().clear();
       var oLayer = mviewer.getLayers()[idlayer];
@@ -213,7 +209,12 @@ const fileimport = (function () {
       ];
       if (zipMimeTypes.includes(file.type)) {
         _unzip(file, oLayer);
-      } else if (["application/geo+json", "application/json"].includes(file.type)) {
+
+        // regex fix windows OS empty type with .geojson format
+      } else if (
+        /\.geojson$/i.test(file.name) ||
+        ["application/geo+json", "application/json"].includes(file.type)
+      ) {
         // Load GeoJSON directly
         var reader = new FileReader();
         reader.onload = function (evt) {

--- a/demo/addons/fileimport/fileimport.js
+++ b/demo/addons/fileimport/fileimport.js
@@ -174,7 +174,7 @@ const fileimport = (function () {
     return `<div class="dropzone dz-clickable" id="drop_zone" onclick="$('#loadcsv-${oLayer.layerid}').click();" ondrop="fileimport.dropHandler(event);" ondragover="fileimport.dragOverHandler(event);">
                   <div id="csv-status" class="start">
                       <div class="dz-default dz-message"><span class="fas fa-cloud-upload-alt fa-3x"></span>
-                          <p i18n="fileimport.upload.dropzone">Glisser un fichier CSV ou SHP (en ZIP) ici ou clic pour sélectionner un fichier...</p>
+                          <p i18n="fileimport.upload.dropzone">Glisser un fichier GeoJSON, CSV ou SHP (en ZIP) ici ou clic pour sélectionner un fichier...</p>
                       </div>
                       <div class="dz-work dz-message"><span class="fas fa-spin fa-cog fa-3x"></span>
                           <p i18n="fileimport.upload.processing">Traitement en cours</p>
@@ -209,6 +209,13 @@ const fileimport = (function () {
       ];
       if (zipMimeTypes.includes(file.type)) {
         _unzip(file, oLayer);
+      } else if (["application/geo+json"].includes(file.type)) {
+        // Load GeoJSON directly
+        var reader = new FileReader();
+        reader.onload = function (evt) {
+          loadGeoJson(oLayer, oLayer.layer, evt.target.result);
+        };
+        reader.readAsText(file);
       } else {
         _initCsvModal(idlayer, file, oLayer);
       }
@@ -552,7 +559,7 @@ const fileimport = (function () {
                 features: features,
               })
             );
-            mviewer.getMap().getView().fit(featureSource.getExtent());
+            utils.zoomToFeaturesExtent(featureSource.getFeatures());
             // set legend
             var legendStyle = getImportStyle(oLayer.layer.getSource().getFeatures()[0]);
             var geometryType = oLayer.layer
@@ -645,7 +652,10 @@ const fileimport = (function () {
         var feature = new ol.Feature({
           geometry: new ol.geom.Point(
             ol.proj.transform(
-              [parseFloat(a[oLayer.xfield]), parseFloat(a[oLayer.yfield])],
+              [
+                parseFloat(a[oLayer.xfield].replace(",", ".")),
+                parseFloat(a[oLayer.yfield].replace(",", ".")),
+              ],
               ol.proj.get(_epsg),
               oLayer.mapProjection
             )
@@ -661,12 +671,7 @@ const fileimport = (function () {
     // if fusesearch is enabled in config, 'change' event is fired and handled in the  _processSearchableLayer method (search.js)
     _source.addFeatures(_features);
     // zoom to layer extent
-    mviewer.getMap().getView().fit(_source.getExtent());
-    let zoom = mviewer.getMap().getView().getZoom();
-    mviewer
-      .getMap()
-      .getView()
-      .setZoom(zoom - 1);
+    utils.zoomToFeaturesExtent(_source.getFeatures());
     $("#csv-status").attr("class", "start");
     //draw layer Legend
     oLayer.legend = {
@@ -687,22 +692,26 @@ const fileimport = (function () {
    * @param {Object} oLayer
    * @param {Object} l
    */
-  var _loadCSV = function (oLayer, l) {
-    // No wizard here. file is directly geocoded at startup. Used with persistant csv with layer config parameters (geocodingfields...)
+  let _loadCSV = function (oLayer, l) {
+    // No wizard here. file is directly geocoded at startup. Used with persistent csv with layer config parameters (geocodingfields...)
     if (oLayer.url && oLayer.geocoder) {
-      $.ajax({
-        url: oLayer.url,
-        success: function (data) {
+      fetch(oLayer.url)
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(response.statusText || "HTTP error");
+          }
+          return response.text();
+        })
+        .then((data) => {
           _geocode(data, oLayer, l);
-        },
-        error: function (xhr, ajaxOptions, thrownError) {
-          var alertText = _getI18NAlertMessage(
+        })
+        .catch((error) => {
+          const alertText = _getI18NAlertMessage(
             "Problème avec la récupération du fichier csv",
             "fileimport.alert.fileloading"
           );
-          mviewer.alert(alertText + thrownError, "alert-warning");
-        },
-      });
+          mviewer.alert(`${alertText}: ${error.message}`, "alert-warning");
+        });
     }
   };
 
@@ -749,6 +758,50 @@ const fileimport = (function () {
     return mviewer.lang ? mviewer.lang[mviewer.lang.lang](messageId) : message;
   };
 
+  /**
+   * Public method loadGeoJson
+   * Loads a GeoJSON file into the given layer
+   * @param {Object} oLayer - Layer configuration object
+   * @param {Object} l - OpenLayers vector layer
+   * @param {String|Object} geojson - GeoJSON data as string or parsed object
+   */
+  const loadGeoJson = function (oLayer, l, geojson) {
+    try {
+      let _source = l.getSource();
+      l.setStyle(getImportStyle.bind(this));
+
+      // Parse if input is string
+      let data = typeof geojson === "string" ? JSON.parse(geojson) : geojson;
+
+      let features = new ol.format.GeoJSON({
+        featureProjection: oLayer.mapProjection,
+        dataProjection: "EPSG:4326", // Assumes GeoJSON is in WGS84
+      }).readFeatures(data);
+
+      _source.clear();
+      _source.addFeatures(features);
+
+      utils.zoomToFeaturesExtent(features);
+
+      // Generate legend
+      oLayer.legend = {
+        items: [
+          {
+            styles: [getImportStyle(features[0])],
+            label: "GeoJSON",
+            geometry: features[0].getGeometry().getType(),
+          },
+        ],
+      };
+      mviewer.drawVectorLegend(oLayer.layerid, oLayer.legend.items);
+    } catch (err) {
+      let alertText = _getI18NAlertMessage(
+        "Erreur lors du chargement du fichier GeoJSON",
+        "fileimport.alert.geojson"
+      );
+      mviewer.alert(alertText + ": " + err.message, "alert-warning");
+    }
+  };
   return {
     init: function () {
       var layers = mviewer.getLayers();
@@ -831,6 +884,7 @@ const fileimport = (function () {
         ev.dataTransfer.clearData();
       }
     },
+    loadGeoJson: loadGeoJson,
   };
 })();
 

--- a/demo/csv.xml
+++ b/demo/csv.xml
@@ -19,7 +19,7 @@
     </extensions>
     <themes>
         <theme name="csv"  collapsed="false" id="csv" icon="fas fa-users">
-            <layer type="import" id="csv1" name="demo csv"  visible="false"
+            <layer type="import" id="csv1" name="Fichier CSV chargé au démarrage"  visible="false"
                 queryable="true"
                 vectorlegend="true"
                 geocoder="search"
@@ -36,7 +36,7 @@
                 fusesearchresult="{{nom}}"
                 attribution="Dans cet exemple, le fichier csv, persistant et disponible en ligne, est géocodé à l'ouverture de l'application. La recherche est activée">
             </layer>
-            <layer type="import" id="import_file" name="Importer un fichier CSV"  visible="true"
+            <layer type="import" id="import_file" name="Fichier importé (CSV, GeoJSON, SHP)"  visible="true"
                 legendurl="img/blank.gif"
                 queryable="true"
                 vectorlegend="true"

--- a/docs/doc_tech/config_extensions.rst
+++ b/docs/doc_tech/config_extensions.rst
@@ -112,7 +112,13 @@ Cette extension permet d'ajouter une couche dans votre mviewer. Attention, la co
               :alt: Calcul isochrone
               :align: center
 
-| Elle fonctionne avec les formats CSV et Shapefile (via un ZIP).
+
+| Elle fonctionne avec les formats GeoJSON, CSV et Shapefile (via un ZIP).
+
+| Pour le GeoJSON, il sera nécessaire d'utiliser la projection EPSG:4326. La fenêtre modal pour le CSV permettant de choisir la projeciton.
+
+| Pour le CSV, une fenêtre modale vous permettra de configurer une étape de géocodage ou bien une étape d'affichage simple nécessiant de préciser les champs utiles et la projection.
+
 | Il faut pour cela ajouter l'appel à l'extension dans votre XML :
 
 .. code-block:: xml

--- a/js/utils.js
+++ b/js/utils.js
@@ -197,11 +197,46 @@ var utils = (function () {
     return _WMTSTileResolutions[matrixset];
   };
 
+  /**
+   * This function calculates the zoom level for a given extent and map size.
+   * @param {ol.Extent} extent - The extent to calculate the zoom level for.
+   */
+  _calculateZoomExtent = (extent) => {
+    const view = mviewer.getMap().getView();
+    const size = mviewer.getMap().getSize();
+    const resolution = view.getResolutionForExtent(extent, size);
+    return view.getZoomForResolution(resolution);
+  };
+
+  /**
+   * this function zooms the map to the extent of the given features.
+   * @param {array} features
+   */
+  _zoomToFeaturesExtent = (features) => {
+    if (!features || features.length === 0) {
+      return;
+    }
+    const extent = ol.extent.createEmpty();
+    features.forEach((feature) =>
+      ol.extent.extend(extent, feature.getGeometry().getExtent())
+    );
+    const geometry = features[0].getGeometry();
+    const isSinglePoint = features.length < 2 && geometry.getType() === "Point";
+
+    const zoom = isSinglePoint ? 16 : _calculateZoomExtent(extent);
+
+    const center = ol.extent.getCenter(extent);
+
+    mviewer.animateToFeature(center, zoom - 1, center, false);
+  };
+
   return {
     lonlat2osmtile: _lonlat2osmtile,
     testConfiguration: _testConfiguration,
     initWMTSMatrixsets: _initWMTSMatrixsets,
     getWMTSTileMatrix: _getWMTSTileMatrix,
     getWMTSTileResolutions: _getWMTSTileResolutions,
+    calculateZoomExtent: _calculateZoomExtent,
+    zoomToFeaturesExtent: _zoomToFeaturesExtent,
   };
 })();


### PR DESCRIPTION
### Description

Cette PR permet d'ajouter le format GeoJSON à l'addon fileImport.
Cela permettra d'importer un fichier GeoJSON sur la carte comme c'était possible pour un SHP ou un CSV.

Cette PR permet également d'ajouter une fonction utilitaire, afin de faciliter le zoom sur une étendu à partir d'un calcul de niveau de zoom automatique selon les features fournies en paramètre. 

Cette PR permet donc d'utiliser la fonction animateToFeature (rajoutée dernièrement par @raphael-dsc) dans tous l'addon.

**Démo de référence pour les tests : `demo/csv.xml`.**

Le GEOJSON devra être en `EPSG:4326`.

Seul le format .geojson est compatible (le format .json ne sera pas compatible). Ce point est discutable.

### Tests

. Ouvrir `csv.xml`
. importer un fichier `.geojson`