### PR TITLE
Correction de certains blocs selon les modes et la taille d'écran

### DIFF
--- a/css/mviewer.css
+++ b/css/mviewer.css
@@ -313,10 +313,15 @@ html {
 #map {
 	position: fixed;
 	width: 100%;
-	height: 100%;
+	height: calc(100% - var(--mv-navbar-h));
 	z-index: 0;
 	padding: 0;
-	top: 0;
+	top: auto;
+	bottom:0;
+}
+
+.mode-u #map {
+	height: 100%;
 }
 
 .ol-attribution {
@@ -1517,10 +1522,6 @@ li.mv-nav-item {
 
 /* Modal Panel */
 
-#modal-panel .modal-dialog {
-	max-height: 85vh;
-}
-
 #modal-panel .featureInfo__accordion .carousel .active {
 	max-height: 60vh;
 }
@@ -2058,6 +2059,11 @@ body:has(>#main.mode-s) #layers-container-box-header>.btn {
 	padding: 0;
 }
 
+.mode-s:not(.xs) #wrapper.toggled-2 #page-content-wrapper,
+.mode-u:not(.xs) #wrapper.toggled-2 #page-content-wrapper{
+    margin: 0!important;
+}
+
 .mode-s:not(.xs) #bottom-panel,
 .mode-u:not(.xs) #bottom-panel {
 	padding: 0;
@@ -2179,7 +2185,7 @@ body:has(>#main.mode-s) #layers-container-box-header>.btn {
 #mvNavbarMobile {
 	display: none;
 	position: fixed;
-	z-index: 1200;
+	z-index: 1000;
 	bottom: 0;
 	background-color: white;
 	width: 100%;


### PR DESCRIPTION
Suite à la migration vers BS5, cette PR contient les ajustements suivants : 
- Correction des marges de la carte en desktop et en mode s et u (quand menu est fermé), on pouvait constater une marge blanche
- Correction de la hauteur de la carte pour prendre en compte la hauteur de la navbar (permet maintenant aux panneaux draggable de ne plus être masqués dans cette zone)
- Modification de l'index de la barre de navigation mobile (en dessous des modales maintenant)