### PR TITLE
Positionnement des contrôles / fond de plan lorsque la hauteur du bottom panel est en %

### DIFF
--- a/css/mviewer.css
+++ b/css/mviewer.css
@@ -357,11 +357,7 @@ html {
 	z-index: 100;
 }
 
-#page-content-wrapper:has(#bottom-panel.active) .ol-attribution {
-	margin-bottom: var(--mv-bottompanel-size)!important;
-	transition: 0.5s;
-}
-
+#page-content-wrapper:has(#bottom-panel.active) .ol-attribution,
 #page-content-wrapper:has(#bottom-panel.active) .ol-scale-line.ol-unselectable {
 	margin-bottom: var(--mv-bottompanel-size);
 	transition: 0.5s;

--- a/css/mviewer.css
+++ b/css/mviewer.css
@@ -358,13 +358,13 @@ html {
 }
 
 #page-content-wrapper:has(#bottom-panel.active) .ol-attribution {
-	bottom: calc(3em + var(--mv-bottompanel-size))!important;
-	transition: 0.5s ease;
+	margin-bottom: var(--mv-bottompanel-size)!important;
+	transition: 0.5s;
 }
 
 #page-content-wrapper:has(#bottom-panel.active) .ol-scale-line.ol-unselectable {
-	bottom: calc(1em + var(--mv-bottompanel-size));
-	transition: 0.5s ease;
+	margin-bottom: var(--mv-bottompanel-size);
+	transition: 0.5s;
 }
 
 
@@ -471,7 +471,7 @@ html {
 
 #page-content-wrapper:has(#bottom-panel.active) #backgroundlayerstoolbar-gallery,
 #page-content-wrapper:has(#bottom-panel.active) #backgroundlayerstoolbar-default {
-	bottom: calc(1em + var(--mv-bottompanel-size));
+	margin-bottom: var(--mv-bottompanel-size);
 	transition: 0.5s;
 }
 
@@ -489,7 +489,7 @@ html {
 }
 
 #page-content-wrapper:has(#bottom-panel.active) #mouse-position {
-	bottom: calc(1em + var(--mv-bottompanel-size));
+	margin-bottom: var(--mv-bottompanel-size);
 	transition: 0.5s;
 }
 

--- a/css/mviewer.css
+++ b/css/mviewer.css
@@ -357,11 +357,16 @@ html {
 	z-index: 100;
 }
 
-#page-content-wrapper:has(#bottom-panel.active) .ol-attribution.ol-unselectable.ol-control,
-#page-content-wrapper:has(#bottom-panel.active) .ol-scale-line.ol-unselectable {
-	margin-bottom: var(--mv-bottompanel-size);
-	transition: 0.5s;
+#page-content-wrapper:has(#bottom-panel.active) .ol-attribution {
+	bottom: calc(3em + var(--mv-bottompanel-size))!important;
+	transition: 0.5s ease;
 }
+
+#page-content-wrapper:has(#bottom-panel.active) .ol-scale-line.ol-unselectable {
+	bottom: calc(1em + var(--mv-bottompanel-size));
+	transition: 0.5s ease;
+}
+
 
 /* Map-pins */
 
@@ -466,7 +471,7 @@ html {
 
 #page-content-wrapper:has(#bottom-panel.active) #backgroundlayerstoolbar-gallery,
 #page-content-wrapper:has(#bottom-panel.active) #backgroundlayerstoolbar-default {
-	margin-bottom: var(--mv-bottompanel-size);
+	bottom: calc(1em + var(--mv-bottompanel-size));
 	transition: 0.5s;
 }
 
@@ -484,7 +489,7 @@ html {
 }
 
 #page-content-wrapper:has(#bottom-panel.active) #mouse-position {
-	margin-bottom: var(--mv-bottompanel-size);
+	bottom: calc(1em + var(--mv-bottompanel-size));
 	transition: 0.5s;
 }
 

--- a/docs/doc_migration/v4.0.rst
+++ b/docs/doc_migration/v4.0.rst
@@ -262,7 +262,7 @@ Ces variables rendent le thème facilement modifiable et cohérent, sans avoir �
 **Taille des fenêtres d'interrogation**
 
 - ``--mvcustom-rightpanel-size`` : largeur du panel latéral droit (en ``%`` ou ``px``)  
-- ``--mvcustom-bottompanel-size`` : hauteur du panel inférieur (en ``%`` ou ``px``)
+- ``--mvcustom-bottompanel-size`` : hauteur du panel inférieur (en ``vh`` ou ``px``)
 
 **Navbar (barre de navigation)**
 

--- a/docs/doc_migration/v4.0.rst
+++ b/docs/doc_migration/v4.0.rst
@@ -261,7 +261,7 @@ Ces variables rendent le thème facilement modifiable et cohérent, sans avoir �
 
 **Taille des fenêtres d'interrogation**
 
-- ``--mvcustom-rightpanel-size`` : largeur du panel latéral droit (en ``%`` ou ``px``)  
+- ``--mvcustom-rightpanel-size`` : largeur du panel latéral droit (en ``%`` ou ``vw`` ou ``px``)  
 - ``--mvcustom-bottompanel-size`` : hauteur du panel inférieur (en ``vh`` ou ``px``)
 
 **Navbar (barre de navigation)**

--- a/docs/doc_tech/config_css.rst
+++ b/docs/doc_tech/config_css.rst
@@ -167,7 +167,7 @@ Ces variables rendent le thème facilement modifiable et cohérent, sans avoir �
 **Taille des fenêtres d'interrogation**
 
 * ``--mvcustom-rightpanel-size`` : largeur du panneau droit (en ``%`` ou ``px``)
-* ``--mvcustom-bottompanel-size`` : hauteur du panneau inférieur (en ``%`` ou ``px``)
+* ``--mvcustom-bottompanel-size`` : hauteur du panneau inférieur (en ``vh`` ou ``px``)
 
 **Navbar (barre de navigation)**
 

--- a/docs/doc_tech/config_css.rst
+++ b/docs/doc_tech/config_css.rst
@@ -166,7 +166,7 @@ Ces variables rendent le thème facilement modifiable et cohérent, sans avoir �
 
 **Taille des fenêtres d'interrogation**
 
-* ``--mvcustom-rightpanel-size`` : largeur du panneau droit (en ``%`` ou ``px``)
+* ``--mvcustom-rightpanel-size`` : largeur du panneau droit (en ``%`` ou ``vw`` ou ``px``)
 * ``--mvcustom-bottompanel-size`` : hauteur du panneau inférieur (en ``vh`` ou ``px``)
 
 **Navbar (barre de navigation)**


### PR DESCRIPTION
_
> PLUS VALABLE
> Remplacement de `margin-bottom` par `bottom` afin de repositionner correctement les fonds de plan, l’échelle et l’attribution lorsque la hauteur du bottom panel est définie en %.
> 
> L’utilisation de `margin-bottom` entraînait un positionnement incohérent avec des valeurs en pourcentage.

_

⚠️ Il est recommandé d’utiliser des unités en **px ou vh** pour définir la hauteur du bottom panel, afin d’éviter les comportements imprévisibles liés aux calculs en %, j'ai donc mis la documentation à jour.