### PR TITLE
Issue 1267 - Fix _animateToFeature duration and animate

### DIFF
--- a/docs/doc_tech/config_search.rst
+++ b/docs/doc_tech/config_search.rst
@@ -78,8 +78,8 @@ Options liées à la recherche d'adresse *(olscompletion)* et/ou à la recherche
 * ``static`` *(optionnel)* : En lien avec le paramètre doctypes. Active ou désactive la recherche associée à des documents requêtés systématiquement, indépendamment des couches affichées : true ou false (defaut = false).
 * ``inputlabel`` *(optionnel)* : Texte à utiliser pour le placeholder de la zone de saisie de la barre de recherche. default = "Rechercher".
 * ``closeafterclick`` *(optionnel)* : Ferme la liste des résultats de recherche après avoir sélectionné un item : true ou false - defaut = false.
-* ``animate`` *(optionnel)* : Active ou désactive l'animation de la vue lorsqu'un résultat de recherche est sélectionné : true ou false (defaut = false).
-* ``duration`` *(optionnel)* : Durée en ms de l'animation définie dans l'option 'animate' (defaut = 1000).
+* ``animate`` *(optionnel)* : Active ou désactive l'animation de la vue lorsqu'un résultat de recherche est sélectionné : true ou false (defaut = true).
+* ``duration`` *(optionnel)* : Durée en ms de l'animation définie dans l'option 'animate' (defaut = 2000).
 * ``imgurl`` *(optionnel)* : Url de l'image PNG / JPEG à afficher à l'emplacement du résultat sélectionné en guise de pointeur.
 * ``imgwidth`` *(optionnel)* : Taille de l'image (voir paramètre imgurl) du pointeur représentant le résultat sélectionné.
 * ``svgcolor`` *(optionnel)* : Couleur du pointeur représentant la localisation du résultat sélectionné.

--- a/js/search.js
+++ b/js/search.js
@@ -1425,7 +1425,7 @@ var search = (function () {
     let mapProjection = mapView.getProjection().getCode();
     let coordsForQueryMap = ol.proj.transform([lon, lat], _proj4326, mapProjection);
 
-    let duration = 1000;
+    let duration = 2000;
 
     _sourceOverlay.clear();
 


### PR DESCRIPTION
_animationTo_Feature ne prenait pas en compte `animate` et `duration` comme  `zoomToLocation` (qui est déprécié en sa faveur).

J'ai donc réintégré cette possibilité, et je propose aussi de passer de 3000ms de duration par défaut à 1000ms pour se remettre en accord avec la documentation.