### PR TITLE
chore: docker image nginx unprivileged

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /src
 RUN git clone --recurse-submodules https://github.com/mviewer/mviewer.git -b master .
 
 # Final nginx image
-FROM nginx:alpine
+FROM nginxinc/nginx-unprivileged:1.29-alpine3.23
 
 # Copy content and submodule
 COPY --from=gitstage /src /usr/share/nginx/html


### PR DESCRIPTION
switch back to unprivileged docker image
this got removed in commit https://github.com/mviewer/mviewer/commit/0400a02eccae7b89f20a6ca7d85f51f7452ce956

Ideally it would be great to create a new mviewer release for that or override the existing docker image for mviewer 4.1

Originally requested in https://github.com/mviewer/mviewer/pull/892