### PR TITLE
feat: WMS -  Afficher un flux XYZ en couche simple

### DIFF
--- a/docs/doc_tech/config_layers.rst
+++ b/docs/doc_tech/config_layers.rst
@@ -102,6 +102,7 @@ Paramètres pour gérer l'affichage de la couche
 * ``visible`` :guilabel:`studio` :  Booléen stipulant si la couche est visible par défaut.
 * ``opacity`` :guilabel:`studio` : Opacité de la couche (1 par défaut).
 * ``tiled`` :guilabel:`studio` : Booléen stipulant si on désire un affichage tuilé de la couche. Très utile pour affichage de grosses couches.
+* ``xyz`` : Booléen optionnel. Si ``true`` sur une couche ``type="wms"``, mviewer charge l'URL comme un flux raster XYZ (`{z}/{x}/{y}`) au lieu d'émettre des requêtes WMS. Dans ce mode, les paramètres WMS et le GetFeatureInfo ne s'appliquent pas.
 * ``style`` :guilabel:`studio` : Style(s) de la couche. Si plusieurs styles , utiliser la virgule comme séparateur. Si la couche est de type wms, il faut faire référence à un style sld. Si la couche est de type geojson, il faut faire référence à un style définit dans lib/featurestyles.js. Si la couche est de type vector-tms, le style correspond à la valeur indiquée en tant que première clé de la propriété "sources" du fichier de style au format JSON. Si la couche est de type customlayer, le style n'est pas défini ici.
 * ``styleurl`` :guilabel:`studio` : pour les couches de type vector-tms uniquement, il indique l'URL vers le fichier de style au format JSON.
 * ``styletitle`` :guilabel:`studio` : Titres à utiliser pour la liste des styles associés.
@@ -326,4 +327,3 @@ Cet élément optionnel, permet d'associer un template type Mustache (https://gi
 **Paramètres**
 
 * ``url`` :guilabel:`studio` : paramètre obligatoire de type url qui indique l'emplacement du template à utiliser.
-

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -871,6 +871,7 @@ var configuration = (function () {
             oLayer.checked = layer.visible === "true" ? true : false;
             oLayer.visiblebydefault = oLayer.checked ? true : false;
             oLayer.tiled = layer.tiled === "true" ? true : false;
+            oLayer.xyz = layer.xyz === "true" ? true : false;
             oLayer.dynamiclegend = layer.dynamiclegend === "true" ? true : false;
             oLayer.vectorlegend = layer.vectorlegend === "true" ? true : false;
             oLayer.nohighlight =
@@ -1229,42 +1230,83 @@ var configuration = (function () {
       }
     }
 
-    switch (oLayer.tiled) {
-      case true:
-        wms_params["TILED"] = true;
-        source = new ol.source.TileWMS({
-          url: oLayer.url,
-          crossOrigin: _crossorigin,
-          tileLoadFunction: customWmsImageLoader,
-          params: wms_params,
-        });
-        if (oLayer.servertype) {
-          source.set("servertype", oLayer.servertype);
-        }
+    function customXyzTileLoader(tile, src) {
+      if (oLayer.useproxy) {
+        src = _proxy + encodeURIComponent(src);
+      }
 
-        l = new ol.layer.Tile({
-          source: source,
-        });
-        break;
+      var _ba_ident = sessionStorage.getItem(oLayer.url);
+      if (_ba_ident && _ba_ident != "") {
+        var xhr = new XMLHttpRequest();
+        xhr.responseType = "blob";
+        xhr.open("GET", src);
 
-      case false:
-        source = new ol.source.ImageWMS({
-          url: oLayer.url,
-          crossOrigin: _crossorigin,
-          imageLoadFunction: customWmsImageLoader,
-          params: wms_params,
+        xhr.setRequestHeader("Authorization", `Basic ${window.btoa(_ba_ident)}`);
+        xhr.addEventListener("loadend", function () {
+          var data = this.response;
+          if (this.status == "401") {
+            tile.getImage().src = _blankSrc;
+          } else if (data && data !== undefined) {
+            tile.getImage().src = URL.createObjectURL(data);
+          }
         });
-        if (oLayer.servertype) {
-          source.set("servertype", oLayer.servertype);
-        }
-
-        l = new ol.layer.Image({
-          source: source,
-        });
-        break;
+        xhr.onload = function () {
+          tile.getImage().src = src;
+        };
+        xhr.send();
+      } else {
+        tile.getImage().src = src;
+      }
     }
 
-    if (attributeOgcFilter) {
+    if (oLayer.xyz) {
+      source = new ol.source.XYZ({
+        url: oLayer.url,
+        crossOrigin: _crossorigin,
+        tileLoadFunction: customXyzTileLoader,
+      });
+      l = new ol.layer.Tile({
+        source: source,
+      });
+      oLayer.queryable = false;
+    } else {
+      switch (oLayer.tiled) {
+        case true:
+          wms_params["TILED"] = true;
+          source = new ol.source.TileWMS({
+            url: oLayer.url,
+            crossOrigin: _crossorigin,
+            tileLoadFunction: customWmsImageLoader,
+            params: wms_params,
+          });
+          if (oLayer.servertype) {
+            source.set("servertype", oLayer.servertype);
+          }
+
+          l = new ol.layer.Tile({
+            source: source,
+          });
+          break;
+
+        case false:
+          source = new ol.source.ImageWMS({
+            url: oLayer.url,
+            crossOrigin: _crossorigin,
+            imageLoadFunction: customWmsImageLoader,
+            params: wms_params,
+          });
+          if (oLayer.servertype) {
+            source.set("servertype", oLayer.servertype);
+          }
+
+          l = new ol.layer.Image({
+            source: source,
+          });
+          break;
+      }
+    }
+
+    if (attributeOgcFilter && !oLayer.xyz) {
       updateOgcSourceWithFilter(attributeOgcFilter, source);
     }
 

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -3549,7 +3549,12 @@ mviewer = (function () {
       }
 
       var activeStyle = false;
-      if (oLayer.type === "wms" && !oLayer.xyz && sourceParams && sourceParams["STYLES"]) {
+      if (
+        oLayer.type === "wms" &&
+        !oLayer.xyz &&
+        sourceParams &&
+        sourceParams["STYLES"]
+      ) {
         activeStyle = sourceParams["STYLES"];
         var refStyle = activeStyle;
         //update legend image if nec.

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -564,6 +564,8 @@ mviewer = (function () {
       legendUrl = layer.legendurl;
     } else if (layer.legendurl && layer.styles && layer.styles.split(",").length === 1) {
       legendUrl = layer.legendurl;
+    } else if (layer.xyz) {
+      legendUrl = "";
     } else if (layer.type !== "vector-tms") {
       legendUrl = getLegendGraphicUrl(layer.url, _getLegendParams(layer));
     }
@@ -1648,7 +1650,7 @@ mviewer = (function () {
       var layerparams = [];
       if (item.layer.getVisible() && item.showintoc) {
         layerparams.push(item.layerid);
-        if (item.type === "wms") {
+        if (item.type === "wms" && !item.xyz) {
           //get current style if many styles
           var sourceParams = _getWmsSourceParams(item);
           if (item.styles && sourceParams && sourceParams.STYLES) {
@@ -1791,19 +1793,19 @@ mviewer = (function () {
       layerControler.visiblebydefault = true;
       var li = $(`.mv-nav-item[data-layerid='${layerControler.layerid}']`);
       var sourceParams = _getWmsSourceParams(layerControler);
-      if (layerOptions.style && layerControler.type === "wms") {
+      if (layerOptions.style && layerControler.type === "wms" && !layerControler.xyz) {
         if (sourceParams) {
           sourceParams["STYLES"] = layerOptions.style;
         }
         layerControler.style = layerOptions.style;
         layerControler.legendurl = _getlegendurl(layerControler);
       }
-      if (layerOptions.filter && layerControler.type === "wms") {
+      if (layerOptions.filter && layerControler.type === "wms" && !layerControler.xyz) {
         mviewer.setWmsFilterParam(layerControler, sourceParams, layerOptions.filter);
         layerControler.filter = layerOptions.filter;
       }
       mviewer.toggleLayer(li);
-      if (layerOptions.time && layerControler.type === "wms") {
+      if (layerOptions.time && layerControler.type === "wms" && !layerControler.xyz) {
         //layerControler.layer.getSource().getParams()['TIME'] = layerOptions.time;
         var timeControl = $(`#${layerControler.layerid}-layer-timefilter`);
         if (timeControl.hasClass("mv-slider-timer")) {
@@ -3547,7 +3549,7 @@ mviewer = (function () {
       }
 
       var activeStyle = false;
-      if (oLayer.type === "wms" && sourceParams && sourceParams["STYLES"]) {
+      if (oLayer.type === "wms" && !oLayer.xyz && sourceParams && sourceParams["STYLES"]) {
         activeStyle = sourceParams["STYLES"];
         var refStyle = activeStyle;
         //update legend image if nec.


### PR DESCRIPTION
### Tâches

- [x] Documentation
- [x] Code
- [x] Test
- [x] Démo

### Description

Cette PR permet d'utiliser une couche XYZ en couche mviewer.

Jusque là, les XYZ sont utilisées pour les fonds de plan. Mais il est possible d'avoir des flux XYZ (PNG ou JPG) qui ne sont pas des fonds de plan.

Si on les utilise en fond de plan, alors on ne peux plus avoir le fond de plan pour spatialiser les informations remontées de la couche XYZ.

Il est donc intéressant de pouvoir l'utiliser comme couche classique.

### Démonstration

Une démo sera poussée dans la branche master du submodule [demo](https://github.com/mviewer/mviewer-demo).



`                <layer id="seamark_xyz" name="OpenSeaMap Seamarks" type="wms" xyz="true" url="https://t1.openseamap.org/seamark/{z}/{x}/{y}.png" visible="true" queryable="false" expanded="true" />
`

Cet exemple montre qu'on peut avoir une couche avec des marquages (ici maritimes) qu'il est intéressant de superposer avec un fond de plan.

<img width="998" height="869" alt="image" src="https://github.com/user-attachments/assets/78572f51-e90d-4a73-9b5f-ace938a90ac9" />
